### PR TITLE
Build files cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,50 +1,35 @@
+# Ignore the output folder.
 build
 
-src/CommonAssemblyInfo.cs
-src/CommonVersionInfo.h
+# Ignore all */bin/ and */obj/ folders...
+bin/
+obj/
 
-src/*.user
-src/*/*.user
-src/*/*/*.user
-src/*/*/*/*.user
+# ...except the root bin folder (used for build tools and etc.).
+!/bin/
 
-src/*/bin
-src/*/*/bin
-src/*/*/*/bin
+# Ignore backup files.
+*.orig
 
-src/*/obj
-src/*/*/obj
-src/*/*/*/obj
+# Ignore all Visual Studio generated files.
+*.suo
+*.user
+*.ncb
+_ReSharper.*
 
-src/_ReSharper.*
-src/*/_ReSharper.*
-src/*/*/_ReSharper.*
-src/*/*/*/_ReSharper.*
+# Ignore all MonoDevelop generated files.
+*.userprefs
+*.pidb
 
-src/*.suo
-src/*/*.suo
-src/*/*/*.suo
-src/*/*/*/*.suo
+# Ignore all Operating System generated files.
+Thumbs.db
 
-src/*.sln.cache
-src/*/*.sln.cache
-src/*/*/*.sln.cache
-src/*/*/*/*.sln.cache
+# Ignore all Test Suite status files.
+TestResult.xml
+*.VisualState.xml
 
-
-src/Tools/Tools.ncb
-
+# Ignore some other things, too.
 src/Tools/SparkLanguagePackage/*_i.c
 src/Tools/SparkLanguagePackage/*_i.h
 src/Tools/SparkLanguagePackage/*_p.c
 src/Tools/SparkLanguagePackage/PackageLoadKey.h
-
-bin/aspnetmvc/System.Web.Mvc.pdb
-bin/aspnetmvc/Microsoft.Web.Mvc.pdb
-bin/mvccontrib/MvcContrib.pdb
-bin/mvccontrib/MvcContrib.xml
-bin/mvccontrib/MvcContrib.Castle.pdb
-bin/mvccontrib/MvcContrib.Castle.xml
-*.pidb
-*.userprefs
-*Thumbs.db

--- a/spark.build
+++ b/spark.build
@@ -82,18 +82,18 @@
     <echo message="Build Directory is ${build.dir}" />
 
     <exec program="${msbuild.dir}\msbuild.exe"
-				  commandline="${solution.file} /t:Clean /p:Configuration=${project.config};OutDir=${out.dir};SignAssembly=${project.signassembly} /v:q" workingdir="." />
+				  commandline="&quot;${solution.file}&quot; /t:Clean &quot;/p:Configuration=${project.config};OutDir=${out.dir};SignAssembly=${project.signassembly}&quot; /v:q" workingdir="." />
     <exec program="${msbuild.dir}\msbuild.exe"
-				  commandline="${solution.file} /t:Rebuild /p:Configuration=${project.config};OutDir=${out.dir};SignAssembly=${project.signassembly} /v:q" workingdir="." />
+				  commandline="&quot;${solution.file}&quot; /t:Rebuild &quot;/p:Configuration=${project.config};OutDir=${out.dir};SignAssembly=${project.signassembly}&quot; /v:q" workingdir="." />
 
     <if test="${property::exists('tools.solution.file')}">
       <property name="wix-parameters" value="WixTargetsPath=..\..\..\bin\msbuild\Microsoft\WiX\v3.0\wix.targets;WixTasksPath=WixTasks.dll;WixToolPath=..\..\..\bin\wix"/>
       <property name="communitytasks-parameters" value="MSBuildCommunityTasksPath=..\..\..\bin\msbuild\MSBuildCommunityTasks"/>
 
       <exec program="${msbuild.dir}\msbuild.exe"
-            commandline="${tools.solution.file} /t:Clean /p:Configuration=${project.config};OutDir=${out.dir};${wix-parameters};${communitytasks-parameters} /v:q" workingdir="." />
+            commandline="&quot;${tools.solution.file}&quot; /t:Clean &quot;/p:Configuration=${project.config};OutDir=${out.dir};${wix-parameters};${communitytasks-parameters}&quot; /v:q" workingdir="." />
       <exec program="${msbuild.dir}\msbuild.exe"
-            commandline="${tools.solution.file} /t:Rebuild /p:Configuration=${project.config};OutDir=${out.dir};${wix-parameters};${communitytasks-parameters};ProjectFullVersion=${project.fullversion} /v:q" workingdir="." />
+            commandline="&quot;${tools.solution.file}&quot; /t:Rebuild &quot;/p:Configuration=${project.config};OutDir=${out.dir};${wix-parameters};${communitytasks-parameters};ProjectFullVersion=${project.fullversion}&quot; /v:q" workingdir="." />
     </if>
   </target>
 


### PR DESCRIPTION
I cleaned up and fixed the build and ignore files.
- spark.build
  - Fixed an issue with building in paths that contained a space.
- .gitignore
  - Removed entries referencing CommonAssemblyInfo/CommonVersionInfo (**See Note**)
  - Full restructuring of the file.
  - Commented.
  - Removed superfluous entries.

**Note:** I removed the entries for src/CommonAssemblyInfo.cs and src/CommonVersionInfo.h because they were already added to the repo, and the entries had no effect.

If we want the file's changes from the build to be ignored, we may want to consider reverting the files, or adding something like this to the build:

git update-index --assume-unchanged [file]
