### PR TITLE
Unit test grammar

### DIFF
--- a/src/Spark.Tests/Constraints.cs
+++ b/src/Spark.Tests/Constraints.cs
@@ -1,0 +1,102 @@
+﻿//-------------------------------------------------------------------------
+// <copyright file="Constraints.cs">
+// Copyright 2008-2010 Louis DeJardin - http://whereslou.com
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+// <author>Louis DeJardin</author>
+// <author>John Gietzen</author>
+//-------------------------------------------------------------------------
+
+namespace Spark.Tests
+{
+    using System;
+    using NUnit.Framework;
+    using NUnit.Framework.Constraints;
+
+    /// <summary>
+    /// The Is class is a helper class with properties and methods that supply a
+    /// number of constraints used in Asserts.
+    /// </summary>
+    public static class Contains
+    {
+        /// <summary>
+        /// Contains.InOrder returns a constraint that tests whether the actual value
+        /// contains all of the specified items in order.
+        /// </summary>
+        /// <param name="items">The list of items to test.</param>
+        /// <returns>true, if all items are contained within the actual value, in order; false, otherwise.</returns>
+        public static Constraint InOrder(params string[] items)
+        {
+            return new ContainsInOrderConstraint(items);
+        }
+
+        /// <summary>
+        /// A constraint that tests whether the actual value contains all of the specified items in order.
+        /// </summary>
+        private class ContainsInOrderConstraint : Constraint
+        {
+            /// <summary>
+            /// Holds the list of items to test.
+            /// </summary>
+            private readonly string[] items;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ContainsInOrderConstraint"/> class.
+            /// </summary>
+            /// <param name="items">The list of items to test.</param>
+            public ContainsInOrderConstraint(params string[] items)
+            {
+                this.items = items;
+            }
+
+            /// <summary>
+            /// Tests whether the actual value contains all of the specified items in order. 
+            /// </summary>
+            /// <param name="actual">The actual value to test.</param>
+            /// <returns>true, if all items are contained within the actual value, in order; false, otherwise.</returns>
+            public override bool Matches(object actual)
+            {
+                if (actual == null)
+                {
+                    return this.items.Length == 0;
+                }
+
+                var actualString = actual.ToString();
+
+                int index = 0;
+                foreach (string value in this.items)
+                {
+                    int nextIndex = actualString.IndexOf(value, index);
+                    if (nextIndex < 0)
+                    {
+                        return false;
+                    }
+
+                    index = nextIndex + value.Length;
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Writes the constraint description to a MessageWriter.
+            /// </summary>
+            /// <param name="writer">The writer on which the description is displayed.</param>
+            public override void WriteDescriptionTo(MessageWriter writer)
+            {
+                writer.WriteLine("Tests whether the actual value contains all of the specified items in order.");
+            }
+        }
+    }
+}

--- a/src/Spark.Tests/Spark.Tests.csproj
+++ b/src/Spark.Tests/Spark.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Compiler\VisualBasicViewCompilerTester.cs" />
     <Compile Include="Compiler\ExpressionBuilderTester.cs" />
     <Compile Include="Compiler\ForEachInspectorTester.cs" />
+    <Compile Include="Constraints.cs" />
     <Compile Include="DefaultResourcePathManagerTester.cs" />
     <Compile Include="FileSystem\CombinedViewFolderTester.cs" />
     <Compile Include="FileSystem\SubViewFolderTester.cs" />

--- a/src/Spark.Tests/SparkViewFactoryTester.cs
+++ b/src/Spark.Tests/SparkViewFactoryTester.cs
@@ -1,4 +1,6 @@
-// Copyright 2008-2009 Louis DeJardin - http://whereslou.com
+//-------------------------------------------------------------------------
+// <copyright file="SparkViewFactoryTester.cs">
+// Copyright 2008-2010 Louis DeJardin - http://whereslou.com
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,19 +13,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
-using System.Collections.Generic;
-using System.Text;
-using NUnit.Framework;
-using NUnit.Framework.SyntaxHelpers;
-using Rhino.Mocks;
-using Spark.Compiler;
-using Spark.FileSystem;
-using Spark.Tests.Models;
-using Spark.Tests.Stubs;
+// </copyright>
+// <author>Louis DeJardin</author>
+// <author>Gauthier Segay</author>
+// <author>Jacob Proffitt</author>
+// <author>John Gietzen</author>
+//-------------------------------------------------------------------------
 
 namespace Spark.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using NUnit.Framework;
+    using NUnit.Framework.SyntaxHelpers;
+    using Rhino.Mocks;
+    using Spark.Compiler;
+    using Spark.FileSystem;
+    using Spark.Tests.Models;
+    using Spark.Tests.Stubs;
+
     [TestFixture, Category("SparkViewEngine")]
     public class SparkViewFactoryTester
     {
@@ -277,11 +286,11 @@ namespace Spark.Tests
             factory.RenderView(viewContext);
             mocks.VerifyAll();
             string content = sb.ToString();
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<p>Hi Bob!</p>",
                 "<p>Administrator James</p>",
                 "<p>Test user.</p>",
-                "<p>Anonymous user.</p>");
+                "<p>Anonymous user.</p>"));
         }
 
         [Test]
@@ -293,11 +302,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<p>Hi Bob!</p>",
                 "<p>Administrator James</p>",
                 "<p>Test user.</p>",
-                "<p>Anonymous user.</p>");
+                "<p>Anonymous user.</p>"));
         }
         [Test]
         public void ChainingElseIfAttribute()
@@ -307,24 +316,12 @@ namespace Spark.Tests
             factory.RenderView(viewContext);
             mocks.VerifyAll();
             string content = sb.ToString();
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<p>Hi Bob!</p>",
                 "<p>Administrator James</p>",
                 "<p>Test user.</p>",
-                "<p>Anonymous user.</p>");
+                "<p>Anonymous user.</p>"));
         }
-
-        static void ContainsInOrder(string content, params string[] values)
-        {
-            int index = 0;
-            foreach (string value in values)
-            {
-                int nextIndex = content.IndexOf(value, index);
-                Assert.GreaterOrEqual(nextIndex, 0, string.Format("Looking for {0}", value));
-                index = nextIndex + value.Length;
-            }
-        }
-
 
         [Test]
         public void EachAttribute()
@@ -334,11 +331,11 @@ namespace Spark.Tests
             factory.RenderView(viewContext);
             mocks.VerifyAll();
             string content = sb.ToString();
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<td>Bob</td>",
                 "<td>James</td>",
                 "<td>SpecialName</td>",
-                "<td>Anonymous</td>");
+                "<td>Anonymous</td>"));
         }
 
         [Test]
@@ -360,11 +357,11 @@ namespace Spark.Tests
             factory.RenderView(viewContext);
             mocks.VerifyAll();
             string content = sb.ToString();
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<p>Bob</p>", "<p>Alpha</p>",
                 "<p>Bob</p>", "<p>Beta</p>",
                 "<p>Bob</p>", "<p>Gamma</p>",
-                "<span class=\"yadda\">Rating: 5</span>");
+                "<span class=\"yadda\">Rating: 5</span>"));
         }
 
         [Test]
@@ -376,7 +373,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<p>0: Alpha</p>",
                 "<p>1: Beta</p>",
                 "<p>2: Gamma</p>",
@@ -385,7 +382,7 @@ namespace Spark.Tests
                 "<li ", "class=\"odd\">Beta</li>",
                 "<li ", "class=\"even\">Gamma</li>",
                 "<li ", "class=\"odd\">Delta</li>"
-                );
+                ));
         }
 
         [Test]
@@ -397,11 +394,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString().Replace(" ", "").Replace("\t", "").Replace("\r\n", "");
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<tr><td>one</td><td>0</td><td>4</td><td>True</td><td>False</td></tr>",
                 "<tr><td>two</td><td>1</td><td>4</td><td>False</td><td>False</td></tr>",
                 "<tr><td>three</td><td>2</td><td>4</td><td>False</td><td>False</td></tr>",
-                "<tr><td>four</td><td>3</td><td>4</td><td>False</td><td>True</td></tr>");
+                "<tr><td>four</td><td>3</td><td>4</td><td>False</td><td>True</td></tr>"));
         }
 
 
@@ -414,13 +411,13 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<p>out-1</p>",
                             "<p>out-2</p>",
                             "<p>out-3</p>",
                             "<p>out-4</p>",
                             "<p>out-5</p>",
-                            "<p>out-6</p>");
+                            "<p>out-6</p>"));
 
             Assert.IsFalse(content.Contains("fail"));
 
@@ -448,7 +445,9 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
-            ContainsInOrder(content, "Hi there, alpha.", "Hi there, alpha.");
+            Assert.That(content, Contains.InOrder(
+                "Hi there, alpha.",
+                "Hi there, alpha."));
         }
 
         [Test]
@@ -486,10 +485,10 @@ namespace Spark.Tests
 
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<img src=\"/TestApp/content/images/etc.png\"/>",
                 "<script src=\"/TestApp/content/js/etc.js\"/>",
-                "<p class=\"~/blah.css\"/>");
+                "<p class=\"~/blah.css\"/>"));
         }
 
         [Test]
@@ -502,8 +501,8 @@ namespace Spark.Tests
 
             string content = sb.ToString();
 
-            ContainsInOrder(content,
-                "<p>SortByCategory</p>");
+            Assert.That(content, Contains.InOrder(
+                "<p>SortByCategory</p>"));
         }
 
         [Test]
@@ -517,9 +516,9 @@ namespace Spark.Tests
 
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<div>Hello world</div>",
-                "<div>\r\n  Again: Hello world\r\n</div>");
+                "<div>\r\n  Again: Hello world\r\n</div>"));
         }
 
 
@@ -542,7 +541,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "xbox",
                 "xtop",
                 "xb1",
@@ -555,7 +554,7 @@ namespace Spark.Tests
                 "xb4",
                 "xb3",
                 "xb2",
-                "xb1");
+                "xb1"));
         }
 
         [Test]
@@ -567,7 +566,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "xbox",
                 "xtop",
                 "xb1",
@@ -582,7 +581,7 @@ namespace Spark.Tests
                 "xb4",
                 "xb3",
                 "xb2",
-                "xb1");
+                "xb1"));
         }
 
         [Test]
@@ -594,12 +593,12 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                     "<p>",
                     "this.is.some.text:",
                     "test456",
                     "</p>"
-                    );
+                    ));
 
             Assert.IsFalse(content.Contains("<PartialWith.Dot"));
         }
@@ -613,8 +612,8 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
-                "new-var-new-def-set-var");
+            Assert.That(content, Contains.InOrder(
+                "new-var-new-def-set-var"));
         }
 
 
@@ -627,8 +626,8 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
-                "<p>beforedataafter</p>");
+            Assert.That(content, Contains.InOrder(
+                "<p>beforedataafter</p>"));
         }
 
         [Test]
@@ -664,7 +663,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                         "<div>",
                         @"<elt1 a1=""1"" a3=""3""></elt1>",
                         @"<elt2 a1=""1"" a3=""3""></elt2>",
@@ -682,7 +681,7 @@ namespace Spark.Tests
                         @"<elt11 a1=""1"" a3=""3""></elt11>",
                         @"<elt12 a1=""1"" a2=""onetwo"" a3=""3""></elt12>",
                         "</div>"
-            );
+            ));
         }
 
         [Test]
@@ -694,10 +693,10 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<?xml version=\"1.0\" encoding=\"utf-8\" ?>",
                             "<?php yadda yadda yadda ?>"
-                );
+                ));
         }
 
 
@@ -710,9 +709,9 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<li", "class=", "selected", "blah", "</li>",
-                            "blah", "blah");
+                            "blah", "blah"));
 
         }
 
@@ -728,12 +727,12 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<p>", "alpha", "</p>",
                             "<p>", "beta", "</p>",
                             "<p>", "gamma", "</p>",
                             "<p>", "delta", "</p>"
-                            );
+                            ));
         }
 
         [Test]
@@ -748,7 +747,7 @@ namespace Spark.Tests
 
             Assert.IsFalse(content.Contains("default"));
 
-            ContainsInOrder(content, "ok1", "ok2");
+            Assert.That(content, Contains.InOrder("ok1", "ok2"));
             Assert.IsFalse(content.Contains("fail"));
         }
 
@@ -764,7 +763,7 @@ namespace Spark.Tests
 
             Assert.IsFalse(content.Contains("default"));
 
-            ContainsInOrder(content, "ok1", "ok2");
+            Assert.That(content, Contains.InOrder("ok1", "ok2"));
             Assert.IsFalse(content.Contains("fail"));
         }
 
@@ -780,7 +779,7 @@ namespace Spark.Tests
 
             Assert.IsFalse(content.Contains("default"));
 
-            ContainsInOrder(content, "ok1", "ok2");
+            Assert.That(content, Contains.InOrder("ok1", "ok2"));
             Assert.IsFalse(content.Contains("fail"));
         }
 
@@ -796,7 +795,7 @@ namespace Spark.Tests
 
             Assert.IsFalse(content.Contains("default"));
 
-            ContainsInOrder(content, "ok1", "ok2");
+            Assert.That(content, Contains.InOrder("ok1", "ok2"));
             Assert.IsFalse(content.Contains("fail"));
         }
 
@@ -812,7 +811,7 @@ namespace Spark.Tests
 
             Assert.IsFalse(content.Contains("default"));
 
-            ContainsInOrder(content, "ok1", "ok2");
+            Assert.That(content, Contains.InOrder("ok1", "ok2"));
             Assert.IsFalse(content.Contains("fail"));
         }
 
@@ -828,10 +827,10 @@ namespace Spark.Tests
 
             Assert.IsFalse(content.Contains("default"));
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<p>name kaboom *${user.Name}*</p>",
                 "<p>name silently **</p>",
-                "<p>name fixed *fred*</p>");
+                "<p>name fixed *fred*</p>"));
         }
 
         [Test]
@@ -844,7 +843,7 @@ namespace Spark.Tests
             string content = sb.ToString();
 
             Assert.IsFalse(content.Contains("broken"));
-            ContainsInOrder(content, "one", "two", "three", "four", "five");
+            Assert.That(content, Contains.InOrder("one", "two", "three", "four", "five"));
         }
 
         [Test]
@@ -857,14 +856,14 @@ namespace Spark.Tests
             string content = sb.ToString();
 
             Assert.IsFalse(content.Contains("broken"));
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                 "<h1 class=\"one three\"/>",
                 "<h2/>",
                 "<h3 class=\" two three\"/>",
                 "<h4 class=\"one three\"/>",
                 "<h5 class=\"one two\"/>",
                 "<h6/>",
-                "<h7 class=\"one&two<three\"/>");
+                "<h7 class=\"one&two<three\"/>"));
         }
 
 
@@ -877,11 +876,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "foo1",
                             "bar0",
                             "quux2",
-                            "a1");
+                            "a1"));
 
             Assert.IsFalse(content.Contains("foo2"));
             Assert.IsFalse(content.Contains("foo3"));
@@ -900,13 +899,13 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<p>name-0-alpha</p>",
                             "<p>name-1-beta</p>",
                             "<p>name-2-gamma</p>",
                             "<span>one</span>",
                             "<span>two</span>",
-                            "<span>three</span>");
+                            "<span>three</span>"));
         }
 
         [Test]
@@ -918,11 +917,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<p>name-0-alpha</p>",
                             "<p>name-2-gamma</p>",
                             "<span>one</span>",
-                            "<span>three</span>");
+                            "<span>three</span>"));
 
             Assert.IsFalse(content.Contains("beta"));
             Assert.IsFalse(content.Contains("two"));
@@ -937,11 +936,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<p>name-0-alpha</p>",
                             "<span>foo1</span>",
                             "<span>bar0</span>",
-                            "<span>quux2</span>");
+                            "<span>quux2</span>"));
 
             Assert.IsFalse(content.Contains("name-1"));
             Assert.IsFalse(content.Contains("name-2"));
@@ -965,11 +964,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<p><strong>hi</strong></p>",
                             "<p>&lt;strong&gt;hi&lt;/strong&gt;</p>",
                             "yadda",
-                            "<p>42</p>");
+                            "<p>42</p>"));
 
         }
 
@@ -982,11 +981,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            ContainsInOrder(content,
+            Assert.That(content, Contains.InOrder(
                             "<p>3hello</p>",
                             "<p>2hello.</p>",
                             "<p>1hello..</p>",
-                            "<p>0hello...</p>");
+                            "<p>0hello...</p>"));
 
         }
 
@@ -1008,14 +1007,14 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            var stripped = content.Replace(" ", "").Replace("\t","").Replace("\r\n", "");
+            var stripped = content.Replace(" ", "").Replace("\t", "").Replace("\r\n", "");
             Assert.That(stripped, Is.EqualTo(
-                "[001][101]" + 
-                "[201][102]" + 
-                "[201][104][202]" + 
+                "[001][101]" +
+                "[201][102]" +
+                "[201][104][202]" +
                 "[106][002][107]" +
-                "[201][109][202]" + 
-                "[111][202]" + 
+                "[201][109][202]" +
+                "[111][202]" +
                 "[112][003]"));
         }
 
@@ -1046,16 +1045,15 @@ namespace Spark.Tests
 
             string content = sb.ToString();
 
-            ContainsInOrder(content,
-                            "<pre><code>", "code block on the first line", "</code></pre>",
-                            "<p>", "Regular text.", "</p>",
-                            "<pre><code>", "code block indented by spaces", "</code></pre>",
-                            "<p>", "Regular text.", "</p>",
-                            "<pre><code>", "the lines in this block",
-                            "all contain trailing spaces", "</code></pre>",
-                            "<p>", "Regular Text.", "</p>",
-                            "<pre><code>", "code block on the last line", "</code></pre>"
-              );
+            Assert.That(content, Contains.InOrder(
+                "<pre><code>", "code block on the first line", "</code></pre>",
+                "<p>", "Regular text.", "</p>",
+                "<pre><code>", "code block indented by spaces", "</code></pre>",
+                "<p>", "Regular text.", "</p>",
+                "<pre><code>", "the lines in this block",
+                "all contain trailing spaces", "</code></pre>",
+                "<p>", "Regular Text.", "</p>",
+                "<pre><code>", "code block on the last line", "</code></pre>"));
         }
     }
 }


### PR DESCRIPTION
- Added custom NUnit constraints to the Spark.Tests project
  - Constraints.cs
  - Spark.Tests.csproj
- Moved the "ContainsInOrder" function into the Constraints class to clean up the vocabulary of the asserts.
  - Constraints.cs
  - SparkViewFactoryTester.cs
- Converted all tests using "ContainsInOrder" to use the new Constraint syntax.
  - SparkViewFactoryTester.cs
