### PR TITLE
Enhanced error reporting in Batch Compilation scenarios

### DIFF
--- a/src/Spark/Compiler/BatchCompiler.cs
+++ b/src/Spark/Compiler/BatchCompiler.cs
@@ -160,7 +160,7 @@ namespace Spark.Compiler
                         }
                     }
                 }
-                throw new CompilerException(sb.ToString());
+                throw new BatchCompilerException(sb.ToString(), compilerResults);
             }
 
             return compilerResults.CompiledAssembly;

--- a/src/Spark/Compiler/BatchCompilerException.cs
+++ b/src/Spark/Compiler/BatchCompilerException.cs
@@ -1,0 +1,14 @@
+using System.CodeDom.Compiler;
+
+namespace Spark.Compiler
+{
+	public class BatchCompilerException : CompilerException
+	{
+		public BatchCompilerException(string message, CompilerResults results) : base(message)
+		{
+			Results = results;
+		}
+
+		public CompilerResults Results { get; set; }
+	}
+}

--- a/src/Spark/Spark.csproj
+++ b/src/Spark/Spark.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Caching\SpoolWriterOriginator.cs" />
     <Compile Include="Caching\StringWriterOriginator.cs" />
     <Compile Include="Caching\TextWriterOriginator.cs" />
+    <Compile Include="Compiler\BatchCompilerException.cs" />
     <Compile Include="Compiler\NodeVisitors\CacheAttributeVisitor.cs" />
     <Compile Include="Compiler\NodeVisitors\SpecialAttributeVisitorBase.cs" />
     <Compile Include="CompositeViewEntry.cs" />


### PR DESCRIPTION
We are working on getting all of our Spark Views Precompiled during our build.  We have written an MSBuild task which is a thin wrapper over the Spark API. We've got it working, but one of the things we wanted to do that we couldn't do was convert all of the compilation errors to MSBuild errors, and include the filename and line number of each error.  Currently all of that specific information is only included in the giant message which is constructed with a StringBuilder and then attached to the Message of the CompilationException that is thrown by the BatchCompiler object.  The message, while extremely detailed, is overly verbose when written to the console. That leaves greping for that information to be our only option.  This changeset attached to this pull request changes the BatchCompiler to throw a BatchCompilationException, which inherits from CompilationException so that it should be completely backwards compatible.  However, the BatchCompilationException includes the CompilerResults object.  This should allow our MSBuild task to easily report the build errors without the need to grep for the information.
