### PR TITLE
Removed generic constraint of class.

### DIFF
--- a/src/Spark.Web.Mvc/SparkView.cs
+++ b/src/Spark.Web.Mvc/SparkView.cs
@@ -227,7 +227,7 @@ namespace Spark.Web.Mvc
 
     }
 
-    public abstract class SparkView<TModel> : SparkView where TModel : class
+    public abstract class SparkView<TModel> : SparkView
     {
         private ViewDataDictionary<TModel> _viewData;
         private HtmlHelper<TModel> _htmlHelper;


### PR DESCRIPTION
From what I can tell, this isn't needed. It builds, the unit tests run, and examples I've tried with using value types as the model for EditorTemplates works.
