### PR TITLE
Area prioritizaion

### DIFF
--- a/src/Spark.Web.Mvc/DefaultDescriptorBuilder.cs
+++ b/src/Spark.Web.Mvc/DefaultDescriptorBuilder.cs
@@ -208,15 +208,40 @@ namespace Spark.Web.Mvc
 
         protected virtual IEnumerable<string> PotentialMasterLocations(string masterName, IDictionary<string, object> extra)
         {
+            if (extra.ContainsKey("area") && !string.IsNullOrEmpty(extra["area"] as string))
+            {
+                return ApplyFilters(new[]
+                                    {
+                                        string.Format("~{0}Areas{0}{1}{0}Views{0}Layouts{0}{2}.spark", Path.DirectorySeparatorChar, extra["area"], masterName),
+                                        string.Format("~{0}Areas{0}{1}{0}Views{0}Shared{0}{2}.spark", Path.DirectorySeparatorChar, extra["area"], masterName),
+                                        string.Format("Layouts{0}{1}.spark", Path.DirectorySeparatorChar,masterName),
+                                        string.Format("Shared{0}{1}.spark", Path.DirectorySeparatorChar,masterName),
+                                    }, extra);
+            }
             return ApplyFilters(new[]
                                     {
                                         string.Format("Layouts{0}{1}.spark", Path.DirectorySeparatorChar,masterName),
-                                        string.Format("Shared{0}{1}.spark", Path.DirectorySeparatorChar,masterName)
+                                        string.Format("Shared{0}{1}.spark", Path.DirectorySeparatorChar,masterName),
                                     }, extra);
         }
 
         protected virtual IEnumerable<string> PotentialDefaultMasterLocations(string controllerName, IDictionary<string, object> extra)
         {
+            if (extra.ContainsKey("area") && !string.IsNullOrEmpty(extra["area"] as string))
+            {
+                return ApplyFilters(new[]
+                                    {
+                                        string.Format("~{0}Areas{0}{1}{0}Views{0}Layouts{0}{2}.spark", Path.DirectorySeparatorChar, extra["area"], controllerName),
+                                        string.Format("~{0}Areas{0}{1}{0}Views{0}Shared{0}{2}.spark", Path.DirectorySeparatorChar, extra["area"], controllerName),
+                                        string.Format("Layouts{0}{1}.spark", Path.DirectorySeparatorChar, controllerName),
+                                        string.Format("Shared{0}{1}.spark", Path.DirectorySeparatorChar, controllerName),
+                                        string.Format("~{0}Areas{0}{1}{0}Views{0}Layouts{0}Application.spark", Path.DirectorySeparatorChar, extra["area"]),
+                                        string.Format("~{0}Areas{0}{1}{0}Views{0}Shared{0}Application.spark", Path.DirectorySeparatorChar, extra["area"]),
+                                        string.Format("Layouts{0}Application.spark", Path.DirectorySeparatorChar),
+                                        string.Format("Shared{0}Application.spark", Path.DirectorySeparatorChar),
+                                    }, extra);
+            }
+
             return ApplyFilters(new[]
                                     {
                                         string.Format("Layouts{0}{1}.spark", Path.DirectorySeparatorChar, controllerName),


### PR DESCRIPTION
If you are using asp.net mvc areas you may find that some views do not work as well as layouts. There is already an issue logged that describes problems with the mvc areas implementation.

This pull request prioritizes the view search paths to include area view locations first.

It also adds area locations for explicit layouts as well as default layouts. If you have a view that is served by an area folder, you would expect that it would check if there is a layout inside that area before it checks the root layouts folders.

For example, if you have an _admin_ area and you want to display the _index_ view with a default admin themed layout, it should check if _~/areas/admin/views/layouts/admin.spark_ exists first rather than _~/views/layouts/admin.spark_. This reinforces the spirit of areas, but falls back to standard locations if that fails.
## 

This pull request is based on the mvc2-net4 branch, and has been tested in that environment. I would assume that the same style of patch could be applied to master as well as the other mvc branches. If you would like I can create pull requests for those as well.
