### PR TITLE
Switching from Activator.CreateInstance to a caching version

### DIFF
--- a/src/Spark.Python.Tests/PythonViewCompilerTests.cs
+++ b/src/Spark.Python.Tests/PythonViewCompilerTests.cs
@@ -56,7 +56,7 @@ namespace Spark.Python.Tests
 
         private string ExecuteView(StubViewData viewData)
         {
-            var view = (StubSparkView)Activator.CreateInstance(_compiler.CompiledType);
+            var view = FastActivator<StubSparkView>.New(_compiler.CompiledType);
             _languageFactory.InstanceCreated(_compiler, view);
             view.ViewData = viewData;
             var contents = new StringWriter();
@@ -71,7 +71,7 @@ namespace Spark.Python.Tests
         {
             var chunks = Chunks(new SendLiteralChunk { Text = "Hello" });
             _compiler.CompileView(chunks, chunks);
-            var view = (IScriptingSparkView)Activator.CreateInstance(_compiler.CompiledType);
+            var view = FastActivator<IScriptingSparkView>.New(_compiler.CompiledType);
             var source = _compiler.SourceCode;
             var script = view.ScriptSource;
             Assert.IsNotNull(source);

--- a/src/Spark.Ruby.Tests/RubyViewCompilerTests.cs
+++ b/src/Spark.Ruby.Tests/RubyViewCompilerTests.cs
@@ -56,7 +56,7 @@ namespace Spark.Ruby.Tests
 
         private string ExecuteView(StubViewData viewData)
         {
-            var view = (StubSparkView)Activator.CreateInstance(_compiler.CompiledType);
+            var view = FastActivator<StubSparkView>.New(_compiler.CompiledType);
             _languageFactory.InstanceCreated(_compiler, view);
             view.ViewData = viewData;
             var contents = new StringWriter();
@@ -71,7 +71,7 @@ namespace Spark.Ruby.Tests
         {
             var chunks = Chunks(new SendLiteralChunk { Text = "Hello" });
             _compiler.CompileView(chunks, chunks);
-            var view = (IScriptingSparkView)Activator.CreateInstance(_compiler.CompiledType);
+            var view = FastActivator<IScriptingSparkView>.New(_compiler.CompiledType);
             var source = _compiler.SourceCode;
             var script = view.ScriptSource;
             Assert.IsNotNull(source);

--- a/src/Spark.Tests/ViewActivatorTester.cs
+++ b/src/Spark.Tests/ViewActivatorTester.cs
@@ -14,6 +14,7 @@
 // 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -78,6 +79,17 @@ namespace Spark.Tests
         }
 
         [Test]
+        public void FastCreateViewInstance()
+        {
+            var type = typeof(TestView);
+            var factory = new FastViewActivator();
+            var activator = factory.Register(type);
+            var view = activator.Activate(type);
+            Assert.IsNotNull(view);
+            Assert.IsAssignableFrom(typeof(TestView), view);
+        }
+
+        [Test]
         public void CustomViewActivator()
         {
             var engine = new SparkViewEngine(
@@ -92,6 +104,39 @@ namespace Spark.Tests
 
             Assert.IsNotNull(view);
             Assert.IsAssignableFrom(typeof(TestView), view);
+        }
+
+        [Test, Explicit]
+        public void PerfTest()
+        {
+            var type = typeof(TestView);
+            var defFactory = new DefaultViewActivator();
+            var fastFactory = new FastViewActivator();
+
+            var activator = defFactory.Register(type);
+            var fastActivator = fastFactory.Register(type);
+            var iterations = 1000000;
+
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+
+            for (int i = 0; i < iterations; i++)
+            {
+                var view = activator.Activate(type);
+            }
+            sw.Stop();
+            
+            Console.WriteLine("Default took: {0}ms", sw.Elapsed.TotalMilliseconds);
+            sw.Reset();
+
+            sw.Start();
+
+            for (int i = 0; i < iterations; i++)
+            {
+                var view = fastActivator.Activate(type);
+            }
+            sw.Stop();
+            Console.WriteLine("Fast took: {0}ms", sw.Elapsed.TotalMilliseconds);
         }
     }
 }

--- a/src/Spark/FastViewActivator.cs
+++ b/src/Spark/FastViewActivator.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Spark
+{
+    public class FastViewActivator : IViewActivatorFactory, IViewActivator
+    {
+        private static Dictionary<Type, Func<ISparkView>> _ctors = new Dictionary<Type, Func<ISparkView>>();
+
+        public IViewActivator Register(Type type)
+        {
+            //you could put a guard clause in here too to ensure the type can be cast to ISparkView
+            if (_ctors.ContainsKey(type)) return this;
+
+            var exp = Expression.New(type);
+            var d = Expression.Lambda<Func<ISparkView>>(exp).Compile();
+            _ctors.Add(type, d);
+
+            return this;
+        }
+
+        public void Unregister(Type type, IViewActivator activator)
+        {
+        }
+
+        public ISparkView Activate(Type type)
+        {
+            return _ctors[type]();
+        }
+
+        public void Release(Type type, ISparkView view)
+        {
+        }
+    }
+}

--- a/src/Spark/Spark.csproj
+++ b/src/Spark/Spark.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Compiler\NodeVisitors\SpecialAttributeVisitorBase.cs" />
     <Compile Include="CompositeViewEntry.cs" />
     <Compile Include="AbstractSparkView.cs" />
+    <Compile Include="FastViewActivator.cs" />
     <Compile Include="ICacheService.cs" />
     <Compile Include="ICacheSignal.cs" />
     <Compile Include="NullCacheService.cs" />


### PR DESCRIPTION
Added some code to help w/ perf gains in spark. This work is largely inspired from the FastActivator in the Magnum project written by @phatboyg. In 1 million iterations this change had a 50% speed up going from 100ms -> 50ms.
