### PR TITLE
Only void tags get self-closed now.

### DIFF
--- a/src/Spark.Tests/Visitors/ChunkBuilderVisitorTester.cs
+++ b/src/Spark.Tests/Visitors/ChunkBuilderVisitorTester.cs
@@ -56,6 +56,41 @@ namespace Spark.Tests.Visitors
             Assert.AreEqual("<img href=\"urn:picture\" alt=\"A Picture&amp;\"/>", ((SendLiteralChunk)visitor.Chunks[0]).Text);
         }
 
+        [TestCase("area")]
+        [TestCase("base")]
+        [TestCase("br")]
+        [TestCase("col")]
+        [TestCase("command")]
+        [TestCase("embed")]
+        [TestCase("hr")]
+        [TestCase("img")]
+        [TestCase("input")]
+        [TestCase("keygen")]
+        [TestCase("link")]
+        [TestCase("meta")]
+        [TestCase("param")]
+        [TestCase("source")]
+        [TestCase("track")]
+        [TestCase("wbr")]
+        public void VoidElementsSelfClose(string tagName)
+        {
+            var elt = new ElementNode(tagName, new AttributeNode[] { }, true);
+            var visitor = new ChunkBuilderVisitor(new VisitorContext());
+            visitor.Accept(elt);
+            Assert.AreEqual(1, visitor.Chunks.Count());
+            Assert.AreEqual(string.Format("<{0}/>", tagName), ((SendLiteralChunk)visitor.Chunks[0]).Text);
+        }
+
+        [Test]
+        public void NonVoidElementDoesNotSelfClose()
+        {
+            var elt = new ElementNode("span", new AttributeNode[]{ }, true);
+            var visitor = new ChunkBuilderVisitor(new VisitorContext());
+            visitor.Accept(elt);
+            Assert.AreEqual(1, visitor.Chunks.Count());
+            Assert.AreEqual("<span></span>", ((SendLiteralChunk)visitor.Chunks[0]).Text);
+        }
+
         [Test]
         public void WritingDocTypes()
         {

--- a/src/Spark/Compiler/NodeVisitors/ChunkBuilderVisitor.cs
+++ b/src/Spark/Compiler/NodeVisitors/ChunkBuilderVisitor.cs
@@ -263,7 +263,15 @@ namespace Spark.Compiler.NodeVisitors
             foreach (var attribute in node.Attributes)
                 Accept(attribute);
 
-            AddLiteral(node.IsEmptyElement ? "/>" : ">");
+            if (node.IsEmptyElement)
+            {
+                bool isVoidElement = voidElements.Contains(node.Name);
+                AddLiteral(isVoidElement ? "/>" : "></" + node.Name + ">");
+            }
+            else
+            {
+                AddLiteral(">");
+            }
         }
 
         protected override void Visit(AttributeNode attributeNode)
@@ -363,6 +371,26 @@ namespace Spark.Compiler.NodeVisitors
 
         private ConditionalChunk _sendAttributeOnce;
         private Chunk _sendAttributeIncrement;
+
+        private static readonly string[] voidElements = new[]
+        {
+            "area",
+            "base",
+            "br",
+            "col",
+            "command",
+            "embed",
+            "hr",
+            "img",
+            "input",
+            "keygen",
+            "link",
+            "meta",
+            "param",
+            "source",
+            "track",
+            "wbr"
+        };
 
         protected override void Visit(ConditionNode conditionNode)
         {


### PR DESCRIPTION
I've changed the ChunkBuilderVisitor so that it only self -closes the void tags specified in the current HTML5 standard.

This prevents the generation of invalid HTML like `<h2/>`, which browsers interpret as an `<h2>` tag that is never closed, but still allows valid cases like `<img src="..."/>`.

We use an MVVM framework that often requires the use of empty elements like `<span data-bind="text: hello"></span>`, and Shade templates like

`span data-bind="text: hello"`

generate:

`<span data-bind="text: hello" />`
