### PR TITLE
Extension point for PartialViewFolderPaths

### DIFF
--- a/src/Spark.Tests/SparkServiceContainerTester.cs
+++ b/src/Spark.Tests/SparkServiceContainerTester.cs
@@ -40,6 +40,9 @@ namespace Spark.Tests
 
             var bindingProvider = container.GetService<IBindingProvider>();
             Assert.IsInstanceOf(typeof(DefaultBindingProvider), bindingProvider);
+
+            var partialProvider = container.GetService<IPartialProvider>();
+            Assert.IsInstanceOf(typeof(DefaultPartialProvider), partialProvider);
         }
 
         [Test]

--- a/src/Spark/DefaultPartialProvider.cs
+++ b/src/Spark/DefaultPartialProvider.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Spark
+{
+    public class DefaultPartialProvider : IPartialProvider
+    {
+        public IEnumerable<string> GetPaths(string viewPath)
+        {
+            do
+            {
+                viewPath = Path.GetDirectoryName(viewPath);
+
+                yield return viewPath;
+                yield return Path.Combine(viewPath, Constants.Shared);
+            }
+            while (!String.IsNullOrEmpty(viewPath));
+        }
+    }
+}

--- a/src/Spark/IPartialProvider.cs
+++ b/src/Spark/IPartialProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Spark
+{
+    public interface IPartialProvider
+    {
+        IEnumerable<string> GetPaths(string viewPath);
+    }
+}

--- a/src/Spark/Parser/ViewLoader.cs
+++ b/src/Spark/Parser/ViewLoader.cs
@@ -37,6 +37,7 @@ namespace Spark.Parser
 
         private readonly List<string> pending = new List<string>();
 
+        private IPartialProvider partialProvider;
 
         public IViewFolder ViewFolder { get; set; }
 
@@ -53,6 +54,19 @@ namespace Spark.Parser
         public AttributeBehaviour AttributeBehaviour { get; set; }
 
         public IBindingProvider BindingProvider { get; set; }
+
+        public IPartialProvider PartialProvider
+        {
+            get
+            {
+                if (partialProvider == null)
+                {
+                    partialProvider = new DefaultPartialProvider();
+                };
+                return partialProvider;
+            }
+            set { partialProvider = value; }
+        }
 
         /// <summary>
         /// Returns a value indicating whether this view loader is current.
@@ -133,16 +147,9 @@ namespace Spark.Parser
         /// </summary>
         /// <param name="viewPath">The view path for which to return partial view paths.</param>
         /// <returns>The full list of possible partial view paths.</returns>
-        private static IEnumerable<string> PartialViewFolderPaths(string viewPath)
+        private IEnumerable<string> PartialViewFolderPaths(string viewPath)
         {
-            do
-            {
-                viewPath = Path.GetDirectoryName(viewPath);
-
-                yield return viewPath;
-                yield return Path.Combine(viewPath, Constants.Shared);
-            }
-            while (!String.IsNullOrEmpty(viewPath));
+            return this.PartialProvider.GetPaths(viewPath);
         }
 
         /// <summary>

--- a/src/Spark/Spark.csproj
+++ b/src/Spark/Spark.csproj
@@ -110,6 +110,8 @@
     <Compile Include="ICacheSignal.cs" />
     <Compile Include="NullCacheService.cs" />
     <Compile Include="Compiler\NodeVisitors\BindingExpansionVisitor.cs" />
+    <Compile Include="DefaultPartialProvider.cs" />
+    <Compile Include="IPartialProvider.cs" />
     <Compile Include="Parser\Offset\OffsetGrammar.cs" />
     <Compile Include="SparkViewBase.cs" />
     <Compile Include="CompiledViewEntry.cs" />

--- a/src/Spark/SparkServiceContainer.cs
+++ b/src/Spark/SparkServiceContainer.cs
@@ -53,6 +53,7 @@ namespace Spark
                     {typeof (IBindingProvider), c => new DefaultBindingProvider()},
                     {typeof (IViewFolder), CreateDefaultViewFolder},
                     {typeof (ICompiledViewHolder), c => new CompiledViewHolder()},
+                    {typeof (IPartialProvider), c => new DefaultPartialProvider()},
                 };
 
 

--- a/src/Spark/SparkViewEngine.cs
+++ b/src/Spark/SparkViewEngine.cs
@@ -53,6 +53,7 @@ namespace Spark
             ResourcePathManager = container.GetService<IResourcePathManager>();
             TemplateLocator = container.GetService<ITemplateLocator>();
             CompiledViewHolder = container.GetService<ICompiledViewHolder>();
+            PartialProvider = container.GetService<IPartialProvider>();
             SetViewFolder(container.GetService<IViewFolder>());
         }
 
@@ -91,6 +92,18 @@ namespace Spark
                 return _bindingProvider;
             }
             set { _bindingProvider = value; }
+        }
+
+        private IPartialProvider _partialProvider;
+        public IPartialProvider PartialProvider
+        {
+            get
+            {
+                if (_partialProvider == null)
+                    _partialProvider = new DefaultPartialProvider();
+                return _partialProvider;
+            }
+            set { _partialProvider = value; }
         }
 
         private static IViewFolder CreateDefaultViewFolder()
@@ -295,7 +308,8 @@ namespace Spark
                 Prefix = Settings.Prefix,
                 BindingProvider = BindingProvider,
                 ParseSectionTagAsSegment = Settings.ParseSectionTagAsSegment,
-                AttributeBehaviour = Settings.AttributeBehaviour
+                AttributeBehaviour = Settings.AttributeBehaviour,
+                PartialProvider = PartialProvider
             };
         }
 
@@ -358,7 +372,7 @@ namespace Spark
                 var entry = new CompiledViewEntry
                                 {
                                     Descriptor = descriptor,
-                                    Loader = new ViewLoader(),
+                                    Loader = new ViewLoader { PartialProvider = PartialProvider },
                                     Compiler = new CSharpViewCompiler { CompiledType = type },
                                     Activator = ViewActivatorFactory.Register(type)
                                 };


### PR DESCRIPTION
added extension point for providing additional partial file locations in ViewLoader.

The use case I am prepping this pull request for is in FubuMVC.ViewEngines, we want to let spark files reach out to other locations to locate partials according to a dependency graph set up between fubu bottles.

Let me know if there are any issues with this as it is presented, I am happy to change it to meet project standards/style if for some reason it is not already.
