### PR TITLE
delegate method on render level 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ _ReSharper.*
 *.dotCover
 *.ncrunchproject
 *crunchsolution*
+*.disposechecksettings
 
 # Ignore all MonoDevelop generated files.
 *.userprefs

--- a/src/Spark/Compiler/CSharp/CSharpViewCompiler.cs
+++ b/src/Spark/Compiler/CSharp/CSharpViewCompiler.cs
@@ -144,12 +144,18 @@ namespace Spark.Compiler.CSharp
             {
                 if (invokeLevel != renderLevel - 1)
                 {
-                    source.WriteLine("using (OutputScope()) {{RenderViewLevel{0}(); Content[\"view\"] = Output;}}", invokeLevel);
+                  source.WriteLine("using (OutputScope()) {{DelegateFirstRender(RenderViewLevel{0}); Content[\"view\"] = Output;}}", invokeLevel);
                 }
                 else
                 {
-
-                    source.WriteLine("        RenderViewLevel{0}();", invokeLevel);
+                    if (renderLevel <= 1)
+                    {
+                     source.WriteLine("        DelegateFirstRender(RenderViewLevel{0});", invokeLevel);
+                    }
+                     else
+                   {
+                     source.WriteLine("        RenderViewLevel{0}();", invokeLevel);
+                   }
                 }
             }
             source.RemoveIndent().WriteLine("}");

--- a/src/Spark/SparkViewBase.cs
+++ b/src/Spark/SparkViewBase.cs
@@ -241,6 +241,10 @@ namespace Spark
         }
 
         public abstract void Render();
+      protected virtual void DelegateFirstRender(Action render)
+       {
+          render();
+        }
     }
 
 }


### PR DESCRIPTION
Having delegation in the render level zero, allows to have a better control of caching in one place rather than to declare it one by one in a spark view.
