### PR TITLE
Adding implementation for PageInstrumentation in HttpContextWrapper

### DIFF
--- a/src/Spark.Web.Mvc/Wrappers/HttpContextWrapper.cs
+++ b/src/Spark.Web.Mvc/Wrappers/HttpContextWrapper.cs
@@ -19,6 +19,7 @@ using System.Security.Permissions;
 using System.Security.Principal;
 using System.Web;
 using System.Web.Caching;
+using System.Web.Instrumentation;
 using System.Web.Profile;
 
 namespace Spark.Web.Mvc.Wrappers
@@ -159,6 +160,11 @@ namespace Spark.Web.Mvc.Wrappers
         {
             get { return _context.User; }
             set { _context.User = value; }
+        }
+
+        public override PageInstrumentationService PageInstrumentation
+        {
+            get { return _context.PageInstrumentation; }
         }
 
         public override void AddError(Exception errorInfo)


### PR DESCRIPTION
This fixes a `NotImplementedException` being thrown when trying to render a Razor page (via `Html.Partial`) from a Spark page. Razor expects `PageInstrumentation` to be implemented.

This [link talks about it](http://forums.asp.net/t/1872001.aspx) a little more in depth.