### PR TITLE
fix stack-overflow exception when parsing an empty shade file

### DIFF
--- a/src/Spark.Tests/Parser/ViewLoaderTester.cs
+++ b/src/Spark.Tests/Parser/ViewLoaderTester.cs
@@ -311,5 +311,31 @@ namespace Spark.Tests.Parser
             Assert.That(partials, Has.None.EqualTo("dontfind2"));
             Assert.That(partials, Has.None.EqualTo("dontfind3"));
         }
+
+        [Test]
+        public void LoadingEmptyFile()
+        {
+            var viewFolder = new InMemoryViewFolder
+            {
+                {Path.Combine("home", "empty.spark"), ""},                                     
+            };
+            var viewLoader = new ViewLoader { SyntaxProvider = new DefaultSyntaxProvider(ParserSettings.DefaultBehavior), ViewFolder = viewFolder };
+            var chunks = viewLoader.Load(Path.Combine("home", "empty.spark"));
+            var everything = viewLoader.GetEverythingLoaded();
+            Assert.AreEqual(1, everything.Count());
+        }
+
+        [Test]
+        public void LoadingEmptyShadeFile()
+        {
+            var viewFolder = new InMemoryViewFolder
+            {
+                {Path.Combine("home", "empty.shade"), ""},                                     
+            };
+            var viewLoader = new ViewLoader { SyntaxProvider = new DefaultSyntaxProvider(ParserSettings.DefaultBehavior), ViewFolder = viewFolder };
+            var chunks = viewLoader.Load(Path.Combine("home", "empty.shade"));
+            var everything = viewLoader.GetEverythingLoaded();
+            Assert.AreEqual(1, everything.Count());
+        }
     }
 }

--- a/src/Spark/Parser/Grammar.cs
+++ b/src/Spark/Parser/Grammar.cs
@@ -184,7 +184,7 @@ namespace Spark.Parser
 
                 var rest = input;
                 var result = parse(rest);
-                while (result != null)
+                while (result != null && !rest.IsSamePosition(result.Rest))
                 {
                     list.Add(result.Value);
                     rest = result.Rest;

--- a/src/Spark/Parser/Position.cs
+++ b/src/Spark/Parser/Position.cs
@@ -85,6 +85,18 @@ namespace Spark.Parser
             this.paintLink = paintLink;
         }
 
+        public bool IsSamePosition(Position position)
+        {
+            if (position == null)
+                throw new ArgumentNullException("position");
+
+            if (object.ReferenceEquals(position, this)) //obviously
+                return true;
+            return position.Column == this.Column
+                   && position.Line == this.Line
+                   && position.Offset == this.Offset;
+        }
+
         public SourceContext SourceContext
         {
             get


### PR DESCRIPTION
I stumbled over this when feeding @sakeproject an empty shade file.
I created a unit test for this, and also added a possible fix.
Empty spark files are not a problem (also confirmed with a unit test).