### PR TITLE
Convert Resource Chunks to JS

### DIFF
--- a/src/Spark/Compiler/Javascript/JavascriptViewCompiler.cs
+++ b/src/Spark/Compiler/Javascript/JavascriptViewCompiler.cs
@@ -46,7 +46,9 @@ namespace Spark.Compiler.Javascript
             // convert some syntax from csharp to javascript
             foreach (var template in viewTemplates)
                 anonymousTypeVisitor.Accept(template);
-
+            foreach (var template in allResources)
+                anonymousTypeVisitor.Accept(template);
+                
             var cumulativeName = "window.Spark";
             foreach (var part in nameParts.Where(p => p != "~"))
             {


### PR DESCRIPTION
Previously, partials would not get converted to JS (they would rendered as spark templates inside of the rendered JS output).