### PR TITLE
SpoolWriter no longer using `System.Configuration` or `System.Web.Configuration`

### DIFF
--- a/src/Spark.Tests/Spool/SpoolWriterTester.cs
+++ b/src/Spark.Tests/Spool/SpoolWriterTester.cs
@@ -1,4 +1,4 @@
-// Copyright 2008-2009 Louis DeJardin - http://whereslou.com
+﻿// Copyright 2008-2009 Louis DeJardin - http://whereslou.com
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ namespace Spark.Tests.Spool
             GC.WaitForPendingFinalizers();
             _cache.Clear();
         }
-
+        
         [Test]
         public void ToStringCombinesResults()
         {
@@ -211,12 +211,28 @@ namespace Spark.Tests.Spool
             Assert.AreEqual(1, countBetween);
             Assert.AreEqual(1, countAfter);
         }
-
+        
         [Test]
         public void EncodingShouldBeUtf8ByDefault()
         {
             var writer = new SpoolWriter();
-            Assert.AreEqual(65001, writer.Encoding.CodePage);
+
+            Assert.Throws<NotSupportedException>(
+                () =>
+                {
+                    var encoding = writer.Encoding;
+                });
+        }
+
+        [Test]
+        public void ToStringWhenCodingIsDifferentFromUtf8()
+        {
+            TextWriter writer = new SpoolWriter();
+            
+            // The accentuated char and unicode emoji shouldn't matter as the SpoolPage just keeps track of the bytes
+            writer.Write("hèllo 🌍");
+            
+            Assert.AreEqual("hèllo 🌍", writer.ToString());
         }
     }
 }

--- a/src/Spark/Spool/SpoolWriter.cs
+++ b/src/Spark/Spool/SpoolWriter.cs
@@ -15,11 +15,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Web.Configuration;
 
 namespace Spark.Spool
 {
@@ -27,7 +25,7 @@ namespace Spark.Spool
     {
         private readonly SpoolPage _first;
         private SpoolPage _last;
-        private Encoding _encoding;
+
         public SpoolWriter()
         {
             _first = new SpoolPage();
@@ -39,19 +37,10 @@ namespace Spark.Spool
             Dispose(false);
         }
 
-        public override Encoding Encoding
-        {
-            get
-            {
-                if(_encoding == null)
-                {
-                    var configSection = ConfigurationManager.GetSection("system.web/globalization") as GlobalizationSection;
-                    _encoding = configSection != null ? configSection.ResponseEncoding : Encoding.UTF8;
-                }
-
-                return _encoding;
-            }
-        }
+        /// <summary>
+        /// Writing is delegated to <see cref="SpoolPage"/>. SpoolPage itself it just a buffer of bytes. Encoding does not matter.
+        /// </summary>
+        public override Encoding Encoding => throw new NotSupportedException("The spool writer is encoding agnostic");
 
         public override void Write(char value)
         {


### PR DESCRIPTION
- The spool writer is encoding agnostic (it send the string as to the spool page that in turns just grabs the string's bytes)
- `Encoding` has to be overridden on `TextWriter` which `SpoolWriter` inherits from; now the property throws a `new NotSupportedException()`
- Added a unit test to illustrate the behaviour