### PR TITLE
Updated dependencies

### DIFF
--- a/src/Castle.MonoRail.Views.Spark.Tests/Castle.MonoRail.Views.Spark.Tests.csproj
+++ b/src/Castle.MonoRail.Views.Spark.Tests/Castle.MonoRail.Views.Spark.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net48</TargetFramework>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <IsPackable>False</IsPackable>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Components.Pagination, Version=1.0.3.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
@@ -26,10 +28,10 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="NUnit" Version="3.13.3" />
-	<PackageReference Include="NUnit.Console" Version="3.15.2" />
-	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-  <PackageReference Include="RhinoMocks" Version="3.6.0" />
+	<PackageReference Include="NUnit" Version="3.14.0" />
+	<PackageReference Include="NUnit.Console" Version="3.16.3" />
+	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  <PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="MonoRail.Tests.Views\Stub\Helper.cs">

--- a/src/Castle.Monorail.Pdf.Tests/Castle.Monorail.Pdf.Tests.csproj
+++ b/src/Castle.Monorail.Pdf.Tests/Castle.Monorail.Pdf.Tests.csproj
@@ -20,9 +20,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="NUnit" Version="3.13.3" />
-	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-	<PackageReference Include="RhinoMocks" Version="3.6.0" />
+	<PackageReference Include="NUnit" Version="3.14.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+	<PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Castle.Monorail.Pdf\Castle.MonoRail.Pdf.csproj" />

--- a/src/Spark.Python.Tests/Spark.Python.Tests.csproj
+++ b/src/Spark.Python.Tests/Spark.Python.Tests.csproj
@@ -20,8 +20,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="NUnit" Version="3.13.3" />
-	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+	<PackageReference Include="NUnit" Version="3.14.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spark.Python\Spark.Python.csproj" />

--- a/src/Spark.Ruby.Tests/Spark.Ruby.Tests.csproj
+++ b/src/Spark.Ruby.Tests/Spark.Ruby.Tests.csproj
@@ -24,8 +24,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="NUnit" Version="3.13.3" />
-	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+	<PackageReference Include="NUnit" Version="3.14.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spark.Ruby\Spark.Ruby.csproj" />

--- a/src/Spark.Tests/Spark.Tests.csproj
+++ b/src/Spark.Tests/Spark.Tests.csproj
@@ -15,10 +15,10 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="NUnit" Version="3.13.3" />
-	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-	<PackageReference Include="Shouldly" Version="4.1.0" />
-	<PackageReference Include="RhinoMocks" Version="3.6.0" />
+	<PackageReference Include="NUnit" Version="3.14.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+	<PackageReference Include="Shouldly" Version="4.2.1" />
+	<PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spark\Spark.csproj" />

--- a/src/Spark.Web.Mvc.Pdf.Tests/Spark.Web.Mvc.Pdf.Tests.csproj
+++ b/src/Spark.Web.Mvc.Pdf.Tests/Spark.Web.Mvc.Pdf.Tests.csproj
@@ -4,15 +4,17 @@
     <TargetFramework>net48</TargetFramework>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <IsPackable>False</IsPackable>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
 	<PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
-	<PackageReference Include="NUnit" Version="3.13.3" />
-	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-	<PackageReference Include="RhinoMocks" Version="3.6.0" />
+	<PackageReference Include="NUnit" Version="3.14.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+	<PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spark.Web.Mvc.Pdf\Spark.Web.Mvc.Pdf.csproj" />

--- a/src/Spark.Web.Mvc.Ruby.Tests/Spark.Web.Mvc.Ruby.Tests.csproj
+++ b/src/Spark.Web.Mvc.Ruby.Tests/Spark.Web.Mvc.Ruby.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net48</TargetFramework>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <IsPackable>False</IsPackable>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="IronRuby.Libraries, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -13,8 +15,8 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <ProjectReference Include="..\Spark.Web.Mvc.Ruby\Spark.Web.Mvc.Ruby.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Spark.Web.Mvc.Tests/Spark.Web.Mvc.Tests.csproj
+++ b/src/Spark.Web.Mvc.Tests/Spark.Web.Mvc.Tests.csproj
@@ -4,14 +4,16 @@
     <TargetFramework>net48</TargetFramework>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <IsPackable>False</IsPackable>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
 	<PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
-	<PackageReference Include="RhinoMocks" Version="3.6.0" />
-	<PackageReference Include="NUnit" Version="3.13.3" />
+	<PackageReference Include="RhinoMocks" Version="3.6.1" />
+	<PackageReference Include="NUnit" Version="3.14.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spark.Web.Mvc\Spark.Web.Mvc.csproj" />

--- a/src/Spark.Web.Tests/Spark.Web.Tests.csproj
+++ b/src/Spark.Web.Tests/Spark.Web.Tests.csproj
@@ -5,6 +5,8 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>Spark</RootNamespace>
     <IsPackable>False</IsPackable>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="SparkControllerFactoryTester.cs" />
@@ -14,10 +16,11 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="NUnit" Version="3.13.3" />
-	<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-	<PackageReference Include="Shouldly" Version="4.1.0" />
-	<PackageReference Include="RhinoMocks" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+	<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+	<PackageReference Include="Shouldly" Version="4.2.1" />
+	<PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spark.Web\Spark.Web.csproj" />

--- a/src/Spark/Spark.csproj
+++ b/src/Spark/Spark.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net48;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>..\SparkKey.snk</AssemblyOriginatorKeyFile>

--- a/src/Spark/SparkSettings.cs
+++ b/src/Spark/SparkSettings.cs
@@ -21,8 +21,22 @@ namespace Spark
 {
     public class SparkSettings : ISparkSettings
     {
-        public SparkSettings()
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public SparkSettings() : this(null)
         {
+            RootPath = AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
+        }
+
+        /// <summary>
+        /// Constructor that lets you specify the <see cref="rootPath"/>.
+        /// </summary>
+        /// <param name="rootPath">The path of the web app folder (the one containing the Views folder)</param>
+        public SparkSettings(string rootPath)
+        {
+            RootPath = rootPath;
+
             _useNamespaces = new List<string>();
             _useAssemblies = new List<string>();
             _resourceMappings = new List<IResourceMapping>();
@@ -34,9 +48,9 @@ namespace Spark
         }
 
         /// <summary>
-        /// Depending on the target framework this value must be determined (E.g. AppDomain.CurrentDomain.SetupInformation.ApplicationBase in .net framework) or set.
+        /// The path of the web app folder (the one containing the Views folder).
         /// </summary>
-        public string RootPath => AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
+        public string RootPath { get; set; }
 
         public bool Debug { get; set; }
         public NullBehaviour NullBehaviour { get; set; }
@@ -64,24 +78,28 @@ namespace Spark
         public SparkSettings SetDebug(bool debug)
         {
             Debug = debug;
+
             return this;
         }
 
         public SparkSettings SetAutomaticEncoding(bool automaticEncoding)
         {
             AutomaticEncoding = automaticEncoding;
+
             return this;
         }
 
         public SparkSettings SetStatementMarker(string statementMarker)
         {
             StatementMarker = statementMarker;
+
             return this;
         }
 
         public SparkSettings SetNullBehaviour(NullBehaviour nullBehaviour)
         {
             NullBehaviour = nullBehaviour;
+
             return this;
         }
 
@@ -93,18 +111,31 @@ namespace Spark
         public SparkSettings SetPageBaseType(string typeName)
         {
             PageBaseType = typeName;
+
             return this;
         }
 
+        /// <summary>
+        /// Sets the type each spark page should inherit from.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns></returns>
         public SparkSettings SetPageBaseType(Type type)
         {
             PageBaseType = type.FullName;
+
             return this;
         }
 
+        /// <summary>
+        /// Specifies the <see cref="LanguageType"/> the spark view should be compiled to.
+        /// </summary>
+        /// <param name="language"></param>
+        /// <returns></returns>
         public SparkSettings SetDefaultLanguage(LanguageType language)
         {
             DefaultLanguage = language;
+
             return this;
         }
 
@@ -116,36 +147,42 @@ namespace Spark
         public SparkSettings AddAssembly(string assembly)
         {
             _useAssemblies.Add(assembly);
+
             return this;
         }
 
         public SparkSettings AddAssembly(Assembly assembly)
         {
             _useAssemblies.Add(assembly.FullName);
+
             return this;
         }
 
         public SparkSettings AddNamespace(string ns)
         {
             _useNamespaces.Add(ns);
+
             return this;
         }
 
         public SparkSettings SetPrefix(string prefix)
         {
             Prefix = prefix;
+
             return this;
         }
 
         public SparkSettings SetParseSectionTagAsSegment(bool parseSectionTagAsSegment)
         {
             ParseSectionTagAsSegment = parseSectionTagAsSegment;
+
             return this;
         }
 
         public SparkSettings SetAttributeBehaviour(AttributeBehaviour attributeBehaviour)
         {
             AttributeBehaviour = attributeBehaviour;
+
             return this;
         }
 
@@ -157,6 +194,7 @@ namespace Spark
         public SparkSettings AddResourceMapping(string match, string replace, bool stopProcess)
         {
             _resourceMappings.Add(new SimpleResourceMapping { Match = match, Location = replace, Stop = stopProcess });
+
             return this;
         }
 
@@ -168,6 +206,7 @@ namespace Spark
                 Type = customType.AssemblyQualifiedName,
                 Parameters = parameters
             });
+
             return this;
         }
     }


### PR DESCRIPTION
- No longer targeting .net standard in Spark project
- Default SparkSettings.RootPath value set in constructor