### PR TITLE
Code readability improvements

### DIFF
--- a/src/Castle.MonoRail.Views.Spark.Tests/Helpers/HomeController.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/Helpers/HomeController.cs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+
 using Castle.MonoRail.Framework;
 using Castle.MonoRail.Framework.Helpers;
 
@@ -34,7 +31,6 @@ namespace Castle.MonoRail.Views.Spark.Tests.Helpers
     {
         public void Index()
         {
-            
         }
     }
 }

--- a/src/Castle.MonoRail.Views.Spark.Tests/PrecompileInstallerTests.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/PrecompileInstallerTests.cs
@@ -41,7 +41,6 @@ namespace Castle.MonoRail.Views.Spark.Tests
             precompile.ViewPath = "MonoRail.Tests.Views";
             precompile.DescribeBatch += ((sender, e) => e.Batch.For<StubController>().Include("*").Include("_*"));
 
-            var context = new InstallContext();
             var state = new Hashtable();
 
             parent.Installers.Add(precompile);

--- a/src/Castle.MonoRail.Views.Spark.Tests/SparkBatchCompilerTester.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/SparkBatchCompilerTester.cs
@@ -74,6 +74,7 @@ namespace Castle.MonoRail.Views.Spark.Tests
             Assert.AreEqual(2, descriptors.Count);
             Assert.AreEqual(2, descriptors[0].Templates.Count);
             Assert.AreEqual(2, descriptors[1].Templates.Count);
+
             Assert.That(
                 descriptors.Any(
                     d =>
@@ -174,18 +175,18 @@ namespace Castle.MonoRail.Views.Spark.Tests
             var batch = new SparkBatchDescriptor();
             batch.For<FooController>().Include("index");
             _factory.Engine.ViewFolder = new InMemoryViewFolder { { string.Format("foo{0}index.spark", Path.DirectorySeparatorChar), "<p>foo</p>" } };
+            
             var descriptors = _factory.CreateDescriptors(batch);
+
             Assert.AreEqual(1, descriptors.Count);
             Assert.AreEqual(1, descriptors[0].Accessors.Count);
             Assert.AreEqual(typeof(FooHelper).FullName + " Foo", descriptors[0].Accessors[0].Property);            
         }
     }
 
-
     [Helper(typeof(FooHelper), "Foo")]
     public class FooController : Controller
     {
-
     }
 
     public class FooHelper : AbstractHelper

--- a/src/Castle.MonoRail.Views.Spark.Tests/SparkViewDataTests.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/SparkViewDataTests.cs
@@ -38,8 +38,6 @@ namespace Castle.MonoRail.Views.Spark.Tests
 
             engineContext = new StubEngineContext(new UrlInfo("", "Home", "Index", "/", "castle"));
             controllerContext = new ControllerContext();
-
-
         }
 
         [Test]

--- a/src/Castle.MonoRail.Views.Spark.Tests/SparkViewFactoryTests.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/SparkViewFactoryTests.cs
@@ -25,8 +25,6 @@ namespace Castle.MonoRail.Views.Spark.Tests
     using NUnit.Framework;
     using global::Spark;
     
-
-
     [TestFixture]
     public class SparkViewFactoryTests : SparkViewFactoryTestsBase
 	{
@@ -45,7 +43,7 @@ namespace Castle.MonoRail.Views.Spark.Tests
 			manager.RegisterEngineForView(factory);
 		}
 
-		[Test]
+        [Test]
         public void ExtensionIsSpark()
         {
             mocks.ReplayAll();
@@ -111,10 +109,10 @@ namespace Castle.MonoRail.Views.Spark.Tests
                             "<p>bar+4:11</p>");
         }
 
-		[Test]
-		public void NullBehaviourConfiguredToLenient()
-		{
-			mocks.ReplayAll();
+        [Test]
+        public void NullBehaviourConfiguredToLenient()
+        {
+            mocks.ReplayAll();
             manager.Process(string.Format("Home{0}NullBehaviourConfiguredToLenient", Path.DirectorySeparatorChar), output, engineContext, controller, controllerContext);
 			var content = output.ToString();
 			Assert.IsFalse(content.Contains("default"));
@@ -170,16 +168,16 @@ namespace Castle.MonoRail.Views.Spark.Tests
             Assert.That(output.ToString().Contains("<p>Hello</p>"));            
         }
 
-		[Test, Ignore("No way to mock HttpContext.Current")]
-		public void ControllerHelpersCanBeUsedWhenRenderingMailView()
-		{
-			controller = new Helpers.HomeController();
-			controllerContext.ControllerDescriptor = serviceProvider.ControllerDescriptorProvider.BuildDescriptor(controller);
-			controllerContext.Helpers.Add("bar", new Helpers.TestingHelper());
-			mocks.ReplayAll();
+        [Test, Ignore("No way to mock HttpContext.Current")]
+        public void ControllerHelpersCanBeUsedWhenRenderingMailView()
+        {
+            controller = new Helpers.HomeController();
+            controllerContext.ControllerDescriptor = serviceProvider.ControllerDescriptorProvider.BuildDescriptor(controller);
+            controllerContext.Helpers.Add("bar", new Helpers.TestingHelper());
+            mocks.ReplayAll();
             manager.Process(string.Format("Home{0}ControllerHelperAttributeCanBeUsed", Path.DirectorySeparatorChar), null, output, null);
-			Assert.That(output.ToString().Contains("<p>Hello</p>"));
-		}
+            Assert.That(output.ToString().Contains("<p>Hello</p>"));
+        }
 
         [Test]
         public void LateBoundExpressionShouldCallEval()
@@ -187,27 +185,27 @@ namespace Castle.MonoRail.Views.Spark.Tests
             mocks.ReplayAll();
             propertyBag["hello"] = "world";
             propertyBag["foo"] = 1005.3;
-			using (new CurrentCultureScope(""))
-			{
+            using (new CurrentCultureScope(""))
+            {
 
                 manager.Process(string.Format("Home{0}LateBoundExpressionShouldCallEval", Path.DirectorySeparatorChar), output, engineContext, controller, controllerContext);
-				Assert.That(output.ToString(), Does.Contain(string.Format("<p>world {0:#,##0.00}</p>", 1005.3)));
-			}
+                Assert.That(output.ToString(), Does.Contain(string.Format("<p>world {0:#,##0.00}</p>", 1005.3)));
+            }
         }
     }
 
-	public class CurrentCultureScope : IDisposable
-	{
-		private readonly CultureInfo _culture;
-		public CurrentCultureScope(string name)
-		{
-			_culture = Thread.CurrentThread.CurrentCulture;
-			Thread.CurrentThread.CurrentCulture = new CultureInfo(name);
-		}
-		public void Dispose()
-		{
-			Thread.CurrentThread.CurrentCulture = _culture;
-		}
-	}
+    public class CurrentCultureScope : IDisposable
+    {
+        private readonly CultureInfo _culture;
+        public CurrentCultureScope(string name)
+        {
+            _culture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(name);
+        }
+        public void Dispose()
+        {
+            Thread.CurrentThread.CurrentCulture = _culture;
+        }
+    }
 }
     

--- a/src/Castle.MonoRail.Views.Spark.Tests/ViewComponents/AllFrameworkComponentTests.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/ViewComponents/AllFrameworkComponentTests.cs
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
-using System.Collections.Generic;
+
 using System.IO;
-using System.Linq;
-using System.Text;
-using Castle.MonoRail.Framework.ViewComponents;
 using NUnit.Framework;
 
 namespace Castle.MonoRail.Views.Spark.Tests.ViewComponents
@@ -29,68 +25,83 @@ namespace Castle.MonoRail.Views.Spark.Tests.ViewComponents
         public void AuthenticatedContent()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-AuthenticatedContent.spark", Path.DirectorySeparatorChar));
+
             Assert.That(content.Contains("two"));
             Assert.IsFalse(content.Contains("one"));
         }
+
         [Test]
         public void CaptureFor()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-CaptureFor.spark", Path.DirectorySeparatorChar));
+
             Assert.That(content.Contains("onetwothreefour"));
         }
+
         [Test]
         public void ChildContent()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-ChildContent.spark", Path.DirectorySeparatorChar));
+
             ContainsInOrder(content, "one", "5hello", "two");
         }
+
         [Test]
         public void ColumnRenderer()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-ColumnRenderer.spark", Path.DirectorySeparatorChar));
-            ContainsInOrder(content, 
+
+            ContainsInOrder(
+                content,
                 "*start*",
                 "*firstelement*",
                 "*a*",
                 "*b*",
                 "*c*",
                 "*d*",
-                "*e*",  
+                "*e*",
                 "*f*",
                 "*g*",
                 "*h*",
                 "*endblock*");
         }
+
         [Test, Ignore("Creating a test for each built-in component")]
         public void DiggStylePagination()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-DiggStylePagination.spark", Path.DirectorySeparatorChar));
         }
+
         [Test, Ignore("Creating a test for each built-in component")]
         public void Security()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-Security.spark", Path.DirectorySeparatorChar));
         }
+
         [Test, Ignore("Creating a test for each built-in component")]
         public void SelectStylePagination()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-SelectStylePagination.spark", Path.DirectorySeparatorChar));
         }
+
         [Test, Ignore("Creating a test for each built-in component")]
         public void SiteMap()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-SiteMap.spark", Path.DirectorySeparatorChar));
         }
+
         [Test, Ignore("Creating a test for each built-in component")]
         public void TreeMaker()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-TreeMaker.spark", Path.DirectorySeparatorChar));
         }
+
         [Test, Ignore("Creating a test for each built-in component")]
         public void UpdatePage()
         {
             var content = ExecuteView(string.Format("Home{0}AllFrameworkComponents-UpdatePage.spark", Path.DirectorySeparatorChar));
         }
+
         [Test, Ignore("Creating a test for each built-in component")]
         public void UpdateTag()
         {
@@ -110,6 +121,7 @@ namespace Castle.MonoRail.Views.Spark.Tests.ViewComponents
             Assert.IsNotEmpty(writer.ToString());
             return writer.ToString();
         }
+
         static void ContainsInOrder(string content, params string[] values)
         {
             int index = 0;

--- a/src/Castle.MonoRail.Views.Spark.Tests/ViewComponents/ViewComponentRenderViewTests.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/ViewComponents/ViewComponentRenderViewTests.cs
@@ -30,7 +30,6 @@ namespace Castle.MonoRail.Views.Spark.Tests.ViewComponents
             viewComponentFactory.Registry.AddViewComponent("Widget", typeof(WidgetComponent));
         }
 
-
         [Test]
         public void ComponentCallingRenderView()
         {
@@ -167,7 +166,6 @@ namespace Castle.MonoRail.Views.Spark.Tests.ViewComponents
             }
         }
 
-
         [ViewComponentDetails("OnceWidget")]
         public class OnceWidget : ViewComponent
         {
@@ -176,7 +174,6 @@ namespace Castle.MonoRail.Views.Spark.Tests.ViewComponents
                 RenderView("default");
             }
         }
-
 
         [ViewComponentDetails("UsesGlobalSpark")]
         public class UsesGlobalSpark : ViewComponent

--- a/src/Castle.MonoRail.Views.Spark.Tests/ViewComponents/ViewComponentSectionTests.cs
+++ b/src/Castle.MonoRail.Views.Spark.Tests/ViewComponents/ViewComponentSectionTests.cs
@@ -83,41 +83,41 @@ namespace Castle.MonoRail.Views.Spark.Tests.ViewComponents
             Assert.IsFalse(output.Contains("span each"));
         }
 
-		[Test]
-		public void ComponentWithPartialsInSection()
-		{
-			mocks.ReplayAll();
+        [Test]
+        public void ComponentWithPartialsInSection()
+        {
+            mocks.ReplayAll();
 
-			var writer = new StringWriter();
-		    factory.Process(string.Format("Home{0}ComponentWithPartialsInSection.spark", Path.DirectorySeparatorChar), writer,
-		                    engineContext, controller, controllerContext);
+            var writer = new StringWriter();
+            factory.Process(string.Format("Home{0}ComponentWithPartialsInSection.spark", Path.DirectorySeparatorChar), writer,
+                            engineContext, controller, controllerContext);
 
-			var output = writer.ToString();
-			Assert.IsTrue(output.Contains("this is some text: test123"));
-		}
+            var output = writer.ToString();
+            Assert.IsTrue(output.Contains("this is some text: test123"));
+        }
 
-		[Test]
-		public void NestedComponentInSection()
-		{
-			mocks.ReplayAll();
+        [Test]
+        public void NestedComponentInSection()
+        {
+            mocks.ReplayAll();
 
-			var writer = new StringWriter();
-		    factory.Process(string.Format("Home{0}NestedComponentInSection.spark", Path.DirectorySeparatorChar), writer,
-		                    engineContext, controller, controllerContext);
+            var writer = new StringWriter();
+            factory.Process(string.Format("Home{0}NestedComponentInSection.spark", Path.DirectorySeparatorChar), writer,
+                            engineContext, controller, controllerContext);
 
-			var output = writer.ToString();
-			Assert.IsTrue(output.Contains("header1"));
-			Assert.IsTrue(output.Contains("header2"));
-			Assert.IsTrue(output.Contains("body1"));
-			Assert.IsTrue(output.Contains("body2"));
-			Assert.IsTrue(output.Contains("footer1"));
-			Assert.IsTrue(output.Contains("footer2"));
+            var output = writer.ToString();
+            Assert.IsTrue(output.Contains("header1"));
+            Assert.IsTrue(output.Contains("header2"));
+            Assert.IsTrue(output.Contains("body1"));
+            Assert.IsTrue(output.Contains("body2"));
+            Assert.IsTrue(output.Contains("footer1"));
+            Assert.IsTrue(output.Contains("footer2"));
 
-			Assert.IsFalse(output.Contains("<header>"));
-			Assert.IsFalse(output.Contains("<body>"));
-			Assert.IsFalse(output.Contains("<footer>"));
-			Assert.IsFalse(output.Contains("</ComponentWithSections>"));
-		}
+            Assert.IsFalse(output.Contains("<header>"));
+            Assert.IsFalse(output.Contains("<body>"));
+            Assert.IsFalse(output.Contains("<footer>"));
+            Assert.IsFalse(output.Contains("</ComponentWithSections>"));
+        }
 
         [ViewComponentDetails("ComponentWithSections",Sections="header,body,footer")]
         class ComponentWithSections : ViewComponent

--- a/src/Castle.MonoRail.Views.Spark/Helpers/SparkJavascriptHelper.cs
+++ b/src/Castle.MonoRail.Views.Spark/Helpers/SparkJavascriptHelper.cs
@@ -5,23 +5,26 @@ using Spark;
 
 namespace Castle.MonoRail.Views.Spark.Helpers
 {
-  public class SparkJavascriptHelper : AbstractHelper
-  {
-    public virtual string CompileView()
+    public class SparkJavascriptHelper : AbstractHelper
     {
-      return CompileView(ControllerContext.SelectedViewName);
+        public virtual string CompileView()
+        {
+            return CompileView(ControllerContext.SelectedViewName);
+        }
+
+        public virtual string CompileView(string view)
+        {
+            var viewFactory = new SparkViewFactory();
+
+            var descriptor = new SparkViewDescriptor { Language = LanguageType.Javascript };
+
+            descriptor.AddTemplate($"{this.ControllerContext.ViewFolder}{Path.DirectorySeparatorChar}{view}");
+
+            ((IViewSourceLoaderContainer)viewFactory).ViewSourceLoader = Context.Services.ViewSourceLoader;
+
+            var entry = viewFactory.Engine.CreateEntry(descriptor);
+
+            return entry.SourceCode;
+        }
     }
-
-    public virtual string CompileView(string view)
-    {
-      var viewFactory = new SparkViewFactory();
-      var descriptor = new SparkViewDescriptor {Language = LanguageType.Javascript};
-
-      descriptor.AddTemplate(string.Format("{0}{1}{2}", ControllerContext.ViewFolder, Path.DirectorySeparatorChar, view));
-      ((IViewSourceLoaderContainer)viewFactory).ViewSourceLoader = Context.Services.ViewSourceLoader;
-
-      var entry = viewFactory.Engine.CreateEntry(descriptor);
-      return entry.SourceCode;
-    }
-  }
 }

--- a/src/Castle.MonoRail.Views.Spark/Install/PrecompileInstaller.cs
+++ b/src/Castle.MonoRail.Views.Spark/Install/PrecompileInstaller.cs
@@ -48,7 +48,9 @@ namespace Castle.MonoRail.Views.Spark.Install
 
             var viewPath = ViewPath;
             if (string.IsNullOrEmpty(viewPath))
+            {
                 viewPath = "Views";
+            }
 
             if (!Directory.Exists(Path.Combine(appBasePath, viewPath)) &&
                 Directory.Exists(Path.Combine(appBinPath, viewPath)))
@@ -60,7 +62,9 @@ namespace Castle.MonoRail.Views.Spark.Install
             var viewsLocation = Path.Combine(appBasePath, viewPath);
 
             if (!string.IsNullOrEmpty(TargetAssemblyFile))
-                targetPath = Path.Combine(appBinPath, TargetAssemblyFile);
+            {
+                targetPath = Path.Combine(appBinPath, this.TargetAssemblyFile);
+            }
 
             // this hack enables you to open the web.config as if it was an .exe.config
             File.Create(webFileHack).Close();
@@ -83,15 +87,17 @@ namespace Castle.MonoRail.Views.Spark.Install
             var factory = new SparkViewFactory();
             factory.Service(services);
 
-            // And generate all of the known view/master templates into the target assembly
+            // And generate all the known view/master templates into the target assembly
             var batch = new SparkBatchDescriptor(targetPath);
 
-            // create entries for controller attributes in the parent installer's assembly
+            // Create entries for controller attributes in the parent installer's assembly
             batch.FromAssembly(Parent.GetType().Assembly);
 
-            // and give the containing installer a change to add entries
+            // And give the containing installer a change to add entries
             if (DescribeBatch != null)
-                DescribeBatch(this, new DescribeBatchEventArgs { Batch = batch });
+            {
+                this.DescribeBatch(this, new DescribeBatchEventArgs { Batch = batch });
+            }
 
             factory.Precompile(batch);
 

--- a/src/Castle.MonoRail.Views.Spark/SparkView.cs
+++ b/src/Castle.MonoRail.Views.Spark/SparkView.cs
@@ -145,7 +145,6 @@ namespace Castle.MonoRail.Views.Spark
                 {
                     viewComponentContext.RenderView(viewComponentContext.ViewToRender, Output);
                 }
-
             }
             finally
             {
@@ -161,6 +160,5 @@ namespace Castle.MonoRail.Views.Spark
                 }
             }
         }
-
     }
 }

--- a/src/Castle.MonoRail.Views.Spark/SparkViewFactory.cs
+++ b/src/Castle.MonoRail.Views.Spark/SparkViewFactory.cs
@@ -244,15 +244,9 @@ namespace Castle.MonoRail.Views.Spark
             throw new NotImplementedException();
         }
 
-        public override bool SupportsJSGeneration
-        {
-            get { return false; }
-        }
+        public override bool SupportsJSGeneration => false;
 
-        public override string JSGeneratorFileExtension
-        {
-            get { return null; }
-        }
+        public override string JSGeneratorFileExtension => null;
 
         public override object CreateJSGenerator(JSCodeGeneratorInfo generatorInfo, IEngineContext context,
                                                  IController controller, IControllerContext controllerContext)
@@ -265,7 +259,6 @@ namespace Castle.MonoRail.Views.Spark
         {
             throw new NotImplementedException();
         }
-
 
         public Assembly Precompile(SparkBatchDescriptor batch)
         {

--- a/src/Castle.MonoRail.Views.Spark/Wrappers/IViewSourceLoaderContainer.cs
+++ b/src/Castle.MonoRail.Views.Spark/Wrappers/IViewSourceLoaderContainer.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
+
 using Castle.MonoRail.Framework;
 
 namespace Castle.MonoRail.Views.Spark.Wrappers

--- a/src/Castle.Monorail.Pdf.Tests/Stubs/InjectableStubViewEngineManager.cs
+++ b/src/Castle.Monorail.Pdf.Tests/Stubs/InjectableStubViewEngineManager.cs
@@ -128,7 +128,7 @@ namespace Castle.MonoRail.Pdf.Tests.Stubs
         {
             var codeGen = new JSCodeGenerator();
 
-            return new JSCodeGeneratorInfo(codeGen, new PrototypeGenerator(codeGen), new object[0], new object[0]);
+            return new JSCodeGeneratorInfo(codeGen, new PrototypeGenerator(codeGen), Array.Empty<object>(), Array.Empty<object>());
         }
     }
 

--- a/src/Castle.Monorail.Pdf/FormatReturnBinder.cs
+++ b/src/Castle.Monorail.Pdf/FormatReturnBinder.cs
@@ -14,9 +14,15 @@ namespace Castle.MonoRail.Framework
         {
             //TODO: we can find a better way to do this....
             if (context.UrlInfo.Extension.ToLowerInvariant() == "json")
+            {
                 return new JSONReturnBinderAttribute();
+            }
+
             if (context.UrlInfo.Extension.ToLowerInvariant() == "pdf")
+            {
                 return new PdfReturnBinderAttribute();
+            }
+
             return new NullReturnBinder();
         }
     }

--- a/src/Spark.JsTests/Generate.ashx.cs
+++ b/src/Spark.JsTests/Generate.ashx.cs
@@ -42,12 +42,6 @@ namespace Spark.JsTests
             context.Response.Write(entry.SourceCode);
         }
 
-        public bool IsReusable
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public bool IsReusable => false;
     }
 }

--- a/src/Spark.Python.Tests/PythonViewCompilerTests.cs
+++ b/src/Spark.Python.Tests/PythonViewCompilerTests.cs
@@ -30,7 +30,6 @@ namespace Spark.Python.Tests
         private PythonViewCompiler _compiler;
         private PythonLanguageFactory _languageFactory;
 
-
         [SetUp]
         public void Init()
         {
@@ -62,9 +61,9 @@ namespace Spark.Python.Tests
             var contents = new StringWriter();
             view.RenderView(contents);
             _languageFactory.InstanceReleased(_compiler, view);
+
             return contents.ToString();
         }
-
 
         [Test]
         public void CreatedViewHasScriptProperty()
@@ -74,6 +73,7 @@ namespace Spark.Python.Tests
             var view = FastActivator<IScriptingSparkView>.New(_compiler.CompiledType);
             var source = _compiler.SourceCode;
             var script = view.ScriptSource;
+
             Assert.IsNotNull(source);
             Assert.IsNotEmpty(source);
             Assert.IsNotNull(script);
@@ -87,6 +87,7 @@ namespace Spark.Python.Tests
 
             _compiler.BaseClass = "ThisIsTheBaseClass";
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains(": ThisIsTheBaseClass"));
         }
 
@@ -97,6 +98,7 @@ namespace Spark.Python.Tests
 
             _compiler.BaseClass = "ThisIsTheBaseClass";
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains(": ThisIsTheBaseClass<ThisIsTheModelClass>"));
         }
 
@@ -111,6 +113,7 @@ namespace Spark.Python.Tests
             var chunks = new[] { chunks0[0], chunks1[0] };
             _compiler.CompileView(chunks, chunks);
             var content = ExecuteView();
+
             Assert.AreEqual("420", content);
         }
 
@@ -120,6 +123,7 @@ namespace Spark.Python.Tests
             var chunks = Chunks(new UseNamespaceChunk { Namespace = "AnotherNamespace.ToBe.Used" });
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("Imports AnotherNamespace.ToBe.Used"));
         }
 
@@ -130,6 +134,7 @@ namespace Spark.Python.Tests
 
             _compiler.Descriptor = new SparkViewDescriptor { TargetNamespace = "TargetNamespace.ForThe.GeneratedView" };
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("namespace TargetNamespace.ForThe.GeneratedView"));
         }
 
@@ -140,6 +145,7 @@ namespace Spark.Python.Tests
 
             _compiler.Descriptor = new SparkViewDescriptor { TargetNamespace = "TargetNamespace.ForThe.GeneratedView" };
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("Namespace TargetNamespace.ForThe.GeneratedView"));
             Assert.That(_compiler.SourceCode.Contains("Imports AnotherNamespace.ToBe.Used"));
         }
@@ -151,6 +157,7 @@ namespace Spark.Python.Tests
 
             _compiler.Descriptor = new SparkViewDescriptor { TargetNamespace = "TargetNamespace.ForThe.GeneratedView", Templates = new[] { "one", "two", "three" } };
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("SparkViewAttribute"));
             Assert.That(_compiler.SourceCode.Contains("one"));
             Assert.That(_compiler.SourceCode.Contains("two"));
@@ -163,6 +170,7 @@ namespace Spark.Python.Tests
             var chunks = Chunks();
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("GeneratedViewId"));
             Assert.That(_compiler.SourceCode.Contains("\"" + _compiler.GeneratedViewId + "\""));
         }
@@ -173,6 +181,7 @@ namespace Spark.Python.Tests
             var chunks = Chunks(new SendLiteralChunk { Text = "Hello World" });
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("Hello World"));
         }
 
@@ -182,9 +191,9 @@ namespace Spark.Python.Tests
             var chunks = Chunks(new SendExpressionChunk { Code = "5 + 3", Position = new Position(null, 100, 0, 50, 3, null) });
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("5 + 3"));
         }
-
 
         [Test]
         public void RenderingSimpleView()
@@ -195,15 +204,14 @@ namespace Spark.Python.Tests
             Assert.AreEqual("Hello World", contents);
         }
 
-
         [Test]
         public void CompilingSimpleView()
         {
             var chunks = Chunks(new SendLiteralChunk { Text = "Hello World" });
             _compiler.CompileView(chunks, chunks);
+
             Assert.That(typeof(StubSparkView).IsAssignableFrom(_compiler.CompiledType));
         }
-
 
         [Test]
         public void SettingLocalVariable()
@@ -215,6 +223,7 @@ namespace Spark.Python.Tests
                 new SendExpressionChunk { Code = "x" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("42", contents);
         }
 
@@ -229,6 +238,7 @@ namespace Spark.Python.Tests
                 new SendExpressionChunk { Code = "x" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("42", contents);
         }
 
@@ -239,6 +249,7 @@ namespace Spark.Python.Tests
                 new SendExpressionChunk { Code = "hello" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView(new StubViewData { { "hello", 42 } });
+
             Assert.AreEqual("42", contents);
         }
 
@@ -252,9 +263,11 @@ namespace Spark.Python.Tests
             _compiler.CompileView(chunks, chunks);
 
             var contents = ExecuteView(new StubViewData { { "hello", 42 } });
+
             Assert.AreEqual("42", contents);
 
             var contents2 = ExecuteView();
+
             Assert.AreEqual("55", contents2);
         }
 
@@ -268,6 +281,7 @@ namespace Spark.Python.Tests
                 new SendExpressionChunk { Code = "x + 22" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual(contents, "42");
         }
 
@@ -284,6 +298,7 @@ namespace Spark.Python.Tests
             var chunks = Chunks(scope1, scope2);
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual(contents, "42");
         }
 
@@ -297,6 +312,7 @@ namespace Spark.Python.Tests
                 loop);
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView(new StubViewData { { "numbers", new[] { 1, 2, 3, 4, 5 } } });
+
             Assert.AreEqual("12345", contents);
         }
 
@@ -314,6 +330,7 @@ namespace Spark.Python.Tests
                 macro);
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("hello", contents);
         }
 
@@ -332,6 +349,7 @@ namespace Spark.Python.Tests
                 new SendLiteralChunk { Text = "b" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("aok1b", contents);
         }
 
@@ -358,6 +376,7 @@ namespace Spark.Python.Tests
                 new SendLiteralChunk { Text = "b" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("aok1ok2b", contents);
         }
 
@@ -376,6 +395,7 @@ namespace Spark.Python.Tests
                 new SendLiteralChunk { Text = "b" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("aok1b", contents);
         }
 
@@ -401,6 +421,7 @@ namespace Spark.Python.Tests
                 loop);
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView(new StubViewData { { "numbers", new[] { 0, 1, 2, 3, 4, 7, 2, -4 } } });
+
             Assert.AreEqual("dabcddbd", contents);
         }
 
@@ -417,6 +438,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, new[] { chunks[0], partial[0] });
             var contents = ExecuteView();
+
             Assert.AreEqual("(Hello world)", contents);
         }
 
@@ -428,7 +450,6 @@ namespace Spark.Python.Tests
                 new RenderSectionChunk(),
                 new SendLiteralChunk { Text = "]" });
 
-
             var renderPartial = new RenderPartialChunk { FileContext = new FileContext { Contents = partial[0] } };
             var chunks = Chunks(
                 new SendLiteralChunk { Text = "(" },
@@ -439,6 +460,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, new[] { chunks[0], partial[0] });
             var contents = ExecuteView();
+
             Assert.AreEqual("([From inside caller])", contents);
         }
 
@@ -449,7 +471,6 @@ namespace Spark.Python.Tests
                 new SendLiteralChunk { Text = "[" },
                 new RenderSectionChunk { Name = "foo" },
                 new SendLiteralChunk { Text = "]" });
-
 
             var renderPartial = new RenderPartialChunk { FileContext = new FileContext { Contents = partial[0] } };
             renderPartial.Sections.Add("foo",
@@ -465,6 +486,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, new[] { chunks[0], partial[0] });
             var contents = ExecuteView();
+
             Assert.AreEqual("([From inside caller])", contents);
         }
 
@@ -483,9 +505,9 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("bac", contents);
         }
-
 
         [Test]
         public void CaptureContentToNamedSpool()
@@ -498,6 +520,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("abc", contents);
         }
 
@@ -516,6 +539,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("abe", contents);
         }
 
@@ -544,6 +568,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("42", contents);
         }
 
@@ -560,6 +585,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("1${user.Name}23", contents);
         }
 
@@ -580,6 +606,7 @@ namespace Spark.Python.Tests
                                        {
                                            {"stuff", new[] {6, 2, 7, 4}}
                                        });
+
             Assert.AreEqual("04TrueFalse14FalseFalse24FalseFalse34FalseTrue", contents);
         }
 
@@ -598,6 +625,7 @@ namespace Spark.Python.Tests
 
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("213", contents);
         }
     }

--- a/src/Spark.Python.Tests/ScriptingLanguageFactoryTests.cs
+++ b/src/Spark.Python.Tests/ScriptingLanguageFactoryTests.cs
@@ -39,6 +39,7 @@ namespace Spark.Python.Tests
         {
             var descriptor = new SparkViewDescriptor().SetLanguage(LanguageType.Python);
             var viewCompiler = _engine.LanguageFactory.CreateViewCompiler(_engine, descriptor);
+
             Assert.IsAssignableFrom(typeof(PythonViewCompiler), viewCompiler);
         }
 
@@ -48,6 +49,7 @@ namespace Spark.Python.Tests
             var descriptor = new SparkViewDescriptor().SetLanguage(LanguageType.Python);
             var entry = _engine.CreateEntry(descriptor);
             var view = entry.CreateInstance();
+
             Assert.IsInstanceOf(typeof(StubSparkView), view);
         }
     }

--- a/src/Spark.Python/Compiler/PythonViewCompiler.cs
+++ b/src/Spark.Python/Compiler/PythonViewCompiler.cs
@@ -41,12 +41,15 @@ namespace Spark.Python.Compiler
 
             var globalMembersVisitor = new GlobalMembersVisitor(script, globals);
             foreach(var resource in allResources)
+            {
                 globalMembersVisitor.Accept(resource);
+            }
 
             var globalFunctionsVisitor = new GlobalFunctionsVisitor(script, globals);
             foreach (var resource in allResources)
+            {
                 globalFunctionsVisitor.Accept(resource);
-
+            }
 
             var templateIndex = 0;
             foreach (var template in viewTemplates)
@@ -54,7 +57,10 @@ namespace Spark.Python.Compiler
                 script.Write("def RenderViewLevel").Write(templateIndex).WriteLine("():");
                 script.Indent++;
                 foreach (var global in globals.Keys)
+                {
                     script.Write("global ").WriteLine(global);
+                }
+
                 var generator = new GeneratedCodeVisitor(script, globals);
                 generator.Accept(template);
                 script.Indent--;
@@ -79,7 +85,9 @@ namespace Spark.Python.Compiler
 
             var baseClassGenerator = new BaseClassVisitor { BaseClass = BaseClass };
             foreach (var resource in allResources)
+            {
                 baseClassGenerator.Accept(resource);
+            }
 
             BaseClass = baseClassGenerator.BaseClassTypeName;
 
@@ -102,7 +110,10 @@ namespace Spark.Python.Compiler
                 // [SparkView] attribute
                 source.AppendLine("[global::Spark.SparkViewAttribute(");
                 if (TargetNamespace != null)
-                    source.AppendFormat("    TargetNamespace=\"{0}\",", TargetNamespace).AppendLine();
+                {
+                    source.AppendFormat("    TargetNamespace=\"{0}\",", this.TargetNamespace).AppendLine();
+                }
+
                 source.AppendLine("    Templates = new string[] {");
                 source.Append("      ").AppendLine(string.Join(",\r\n      ",
                                                                Descriptor.Templates.Select(

--- a/src/Spark.Python/PythonLanguageFactory.cs
+++ b/src/Spark.Python/PythonLanguageFactory.cs
@@ -21,12 +21,16 @@ namespace Spark.Python
     public class PythonLanguageFactory : DefaultLanguageFactory
     {
         private PythonEngineManager _PythonEngineManager;
+
         public PythonEngineManager PythonEngineManager
         {
             get
             {
                 if (_PythonEngineManager == null)
-                    Interlocked.CompareExchange(ref _PythonEngineManager, new PythonEngineManager(), null);
+                {
+                    Interlocked.CompareExchange(ref this._PythonEngineManager, new PythonEngineManager(), null);
+                }
+
                 return _PythonEngineManager;
             }
         }
@@ -46,14 +50,17 @@ namespace Spark.Python
 
             var pageBaseType = engine.Settings.PageBaseType;
             if (string.IsNullOrEmpty(pageBaseType))
+            {
                 pageBaseType = engine.DefaultPageBaseType;
+            }
 
             viewCompiler.BaseClass = pageBaseType;
             viewCompiler.Descriptor = descriptor;
             viewCompiler.Debug = engine.Settings.Debug;
-        	viewCompiler.NullBehaviour = engine.Settings.NullBehaviour;
+            viewCompiler.NullBehaviour = engine.Settings.NullBehaviour;
             viewCompiler.UseAssemblies = engine.Settings.UseAssemblies;
             viewCompiler.UseNamespaces = engine.Settings.UseNamespaces;
+
             return viewCompiler;
         }
 

--- a/src/Spark.Ruby.Tests/RubyViewCompilerTests.cs
+++ b/src/Spark.Ruby.Tests/RubyViewCompilerTests.cs
@@ -30,7 +30,6 @@ namespace Spark.Ruby.Tests
         private RubyViewCompiler _compiler;
         private RubyLanguageFactory _languageFactory;
 
-
         [SetUp]
         public void Init()
         {
@@ -62,6 +61,7 @@ namespace Spark.Ruby.Tests
             var contents = new StringWriter();
             view.RenderView(contents);
             _languageFactory.InstanceReleased(_compiler, view);
+
             return contents.ToString();
         }
 
@@ -74,6 +74,7 @@ namespace Spark.Ruby.Tests
             var view = FastActivator<IScriptingSparkView>.New(_compiler.CompiledType);
             var source = _compiler.SourceCode;
             var script = view.ScriptSource;
+
             Assert.IsNotNull(source);
             Assert.IsNotEmpty(source);
             Assert.IsNotNull(script);
@@ -87,6 +88,7 @@ namespace Spark.Ruby.Tests
 
             _compiler.BaseClass = "ThisIsTheBaseClass";
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains(": ThisIsTheBaseClass"));
         }
 
@@ -97,6 +99,7 @@ namespace Spark.Ruby.Tests
 
             _compiler.BaseClass = "ThisIsTheBaseClass";
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains(": ThisIsTheBaseClass<ThisIsTheModelClass>"));
         }
 
@@ -111,6 +114,7 @@ namespace Spark.Ruby.Tests
             var chunks = new[] { chunks0[0], chunks1[0] };
             _compiler.CompileView(chunks, chunks);
             var content = ExecuteView();
+
             Assert.AreEqual("420", content);
         }
 
@@ -120,6 +124,7 @@ namespace Spark.Ruby.Tests
             var chunks = Chunks(new UseNamespaceChunk { Namespace = "AnotherNamespace.ToBe.Used" });
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("Imports AnotherNamespace.ToBe.Used"));
         }
 
@@ -130,6 +135,7 @@ namespace Spark.Ruby.Tests
 
             _compiler.Descriptor = new SparkViewDescriptor { TargetNamespace = "TargetNamespace.ForThe.GeneratedView" };
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("namespace TargetNamespace.ForThe.GeneratedView"));
         }
 
@@ -140,6 +146,7 @@ namespace Spark.Ruby.Tests
 
             _compiler.Descriptor = new SparkViewDescriptor { TargetNamespace = "TargetNamespace.ForThe.GeneratedView" };
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("Namespace TargetNamespace.ForThe.GeneratedView"));
             Assert.That(_compiler.SourceCode.Contains("Imports AnotherNamespace.ToBe.Used"));
         }
@@ -151,6 +158,7 @@ namespace Spark.Ruby.Tests
 
             _compiler.Descriptor = new SparkViewDescriptor { TargetNamespace = "TargetNamespace.ForThe.GeneratedView", Templates = new[] { "one", "two", "three" } };
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("SparkViewAttribute"));
             Assert.That(_compiler.SourceCode.Contains("one"));
             Assert.That(_compiler.SourceCode.Contains("two"));
@@ -163,6 +171,7 @@ namespace Spark.Ruby.Tests
             var chunks = Chunks();
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("GeneratedViewId"));
             Assert.That(_compiler.SourceCode.Contains("\"" + _compiler.GeneratedViewId + "\""));
         }
@@ -173,6 +182,7 @@ namespace Spark.Ruby.Tests
             var chunks = Chunks(new SendLiteralChunk { Text = "Hello World" });
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("Hello World"));
         }
 
@@ -182,6 +192,7 @@ namespace Spark.Ruby.Tests
             var chunks = Chunks(new SendExpressionChunk { Code = "5 + 3", Position = new Position(null, 100, 0, 50, 3, null) });
 
             _compiler.GenerateSourceCode(chunks, chunks);
+
             Assert.That(_compiler.SourceCode.Contains("5 + 3"));
         }
 
@@ -192,6 +203,7 @@ namespace Spark.Ruby.Tests
             var chunks = Chunks(new SendLiteralChunk { Text = "Hello World" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("Hello World", contents);
         }
 
@@ -201,6 +213,7 @@ namespace Spark.Ruby.Tests
         {
             var chunks = Chunks(new SendLiteralChunk { Text = "Hello World" });
             _compiler.CompileView(chunks, chunks);
+
             Assert.That(typeof(StubSparkView).IsAssignableFrom(_compiler.CompiledType));
         }
 
@@ -215,6 +228,7 @@ namespace Spark.Ruby.Tests
                 new SendExpressionChunk { Code = "x" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("42", contents);
         }
 
@@ -229,6 +243,7 @@ namespace Spark.Ruby.Tests
                 new SendExpressionChunk { Code = "x" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView();
+
             Assert.AreEqual("42", contents);
         }
 
@@ -239,6 +254,7 @@ namespace Spark.Ruby.Tests
                 new SendExpressionChunk { Code = "@hello" });
             _compiler.CompileView(chunks, chunks);
             var contents = ExecuteView(new StubViewData { { "hello", 42 } });
+            
             Assert.AreEqual("42", contents);
         }
 
@@ -252,9 +268,11 @@ namespace Spark.Ruby.Tests
             _compiler.CompileView(chunks, chunks);
 
             var contents = ExecuteView(new StubViewData { { "hello", 42 } });
+
             Assert.AreEqual("42", contents);
 
             var contents2 = ExecuteView();
+
             Assert.AreEqual("55", contents2);
         }
 
@@ -265,7 +283,9 @@ namespace Spark.Ruby.Tests
                 new CodeStatementChunk { Code = "x = 20" },
                 new SendExpressionChunk { Code = "x + 22" });
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+
             Assert.AreEqual(contents, "42");
         }
 
@@ -281,7 +301,9 @@ namespace Spark.Ruby.Tests
 
             var chunks = Chunks(scope1, scope2);
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+
             Assert.AreEqual(contents, "42");
         }
 
@@ -294,7 +316,9 @@ namespace Spark.Ruby.Tests
             var chunks = Chunks(
                 loop);
             _compiler.CompileView(chunks, chunks);
+
             var contents = ExecuteView(new StubViewData { { "numbers", new[] { 1, 2, 3, 4, 5 } } });
+            
             Assert.AreEqual("12345", contents);
         }
 
@@ -311,7 +335,9 @@ namespace Spark.Ruby.Tests
                 new SendExpressionChunk { Code = "foo(\"hello\")" },
                 macro);
             _compiler.CompileView(chunks, chunks);
+
             var contents = ExecuteView();
+            
             Assert.AreEqual("hello", contents);
         }
 
@@ -329,7 +355,9 @@ namespace Spark.Ruby.Tests
                 condition2,
                 new SendLiteralChunk { Text = "b" });
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+
             Assert.AreEqual("aok1b", contents);
         }
 
@@ -355,7 +383,9 @@ namespace Spark.Ruby.Tests
                 else2,
                 new SendLiteralChunk { Text = "b" });
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("aok1ok2b", contents);
         }
 
@@ -373,7 +403,9 @@ namespace Spark.Ruby.Tests
                 condition2,
                 new SendLiteralChunk { Text = "b" });
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("aok1b", contents);
         }
 
@@ -398,7 +430,9 @@ namespace Spark.Ruby.Tests
             var chunks = Chunks(
                 loop);
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView(new StubViewData { { "numbers", new[] { 0, 1, 2, 3, 4, 7, 2, -4 } } });
+            
             Assert.AreEqual("dabcddbd", contents);
         }
 
@@ -414,7 +448,9 @@ namespace Spark.Ruby.Tests
                 new SendLiteralChunk { Text = ")" });
 
             _compiler.CompileView(chunks, new[] { chunks[0], partial[0] });
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("(Hello world)", contents);
         }
 
@@ -436,7 +472,9 @@ namespace Spark.Ruby.Tests
             renderPartial.Body.Add(new SendLiteralChunk { Text = "From inside caller" });
 
             _compiler.CompileView(chunks, new[] { chunks[0], partial[0] });
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("([From inside caller])", contents);
         }
 
@@ -447,7 +485,6 @@ namespace Spark.Ruby.Tests
                 new SendLiteralChunk { Text = "[" },
                 new RenderSectionChunk { Name = "foo" },
                 new SendLiteralChunk { Text = "]" });
-
 
             var renderPartial = new RenderPartialChunk { FileContext = new FileContext { Contents = partial[0] } };
             renderPartial.Sections.Add("foo",
@@ -462,7 +499,9 @@ namespace Spark.Ruby.Tests
                 new SendLiteralChunk { Text = ")" });
 
             _compiler.CompileView(chunks, new[] { chunks[0], partial[0] });
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("([From inside caller])", contents);
         }
 
@@ -480,7 +519,9 @@ namespace Spark.Ruby.Tests
                 new SendExpressionChunk { Code = "foo" });
 
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("bac", contents);
         }
 
@@ -495,7 +536,9 @@ namespace Spark.Ruby.Tests
                 new SendLiteralChunk { Text = "c" });
 
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("abc", contents);
         }
 
@@ -513,7 +556,9 @@ namespace Spark.Ruby.Tests
                 new SendExpressionChunk { Code = "x3" });
 
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("abe", contents);
         }
 
@@ -541,7 +586,9 @@ namespace Spark.Ruby.Tests
                 });
 
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("42", contents);
         }
 
@@ -557,7 +604,9 @@ namespace Spark.Ruby.Tests
                 new SendLiteralChunk { Text = "3" });
 
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("1${user.Name => undefined method `Name' for nil:NilClass}23", contents);
         }
 
@@ -574,10 +623,12 @@ namespace Spark.Ruby.Tests
                 new ForEachChunk { Code = "foo in @stuff", Body = loop[0] });
 
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView(new StubViewData
                                        {
                                            {"stuff", new[] {6, 2, 7, 4}}
                                        });
+            
             Assert.AreEqual("04TrueFalse14FalseFalse24FalseFalse34FalseTrue", contents);
         }
 
@@ -595,7 +646,9 @@ namespace Spark.Ruby.Tests
                 new SendLiteralChunk { Text = "3" });
 
             _compiler.CompileView(chunks, chunks);
+            
             var contents = ExecuteView();
+            
             Assert.AreEqual("213", contents);
         }
     }

--- a/src/Spark.Ruby/Compiler/RubyViewCompiler.cs
+++ b/src/Spark.Ruby/Compiler/RubyViewCompiler.cs
@@ -23,10 +23,9 @@ using BaseClassVisitor = Spark.Compiler.CSharp.ChunkVisitors.BaseClassVisitor;
 
 namespace Spark.Ruby.Compiler
 {
-    public class RubyViewCompiler:ViewCompiler
+    public class RubyViewCompiler : ViewCompiler
     {
         public string ScriptHeader { get; set; }
-
 
         public override void CompileView(IEnumerable<IList<Chunk>> viewTemplates, IEnumerable<IList<Chunk>> allResources)
         {
@@ -49,12 +48,15 @@ namespace Spark.Ruby.Compiler
 
             var globalMembersVisitor = new GlobalMembersVisitor(script, globals);
             foreach (var resource in allResources)
+            {
                 globalMembersVisitor.Accept(resource);
+            }
 
             var globalFunctionsVisitor = new GlobalFunctionsVisitor(script, globals);
             foreach (var resource in allResources)
+            {
                 globalFunctionsVisitor.Accept(resource);
-
+            }
 
             var templateIndex = 0;
             foreach (var template in viewTemplates)
@@ -76,7 +78,9 @@ namespace Spark.Ruby.Compiler
 
             var globalInitializeVisitor = new GlobalInitializeVisitor(script);
             foreach(var resource in allResources)
+            {
                 globalInitializeVisitor.Accept(resource);
+            }
 
             for (var renderIndex = 0; renderIndex != templateIndex; ++renderIndex)
             {
@@ -103,7 +107,9 @@ namespace Spark.Ruby.Compiler
 
             var baseClassGenerator = new BaseClassVisitor { BaseClass = BaseClass };
             foreach (var resource in allResources)
+            {
                 baseClassGenerator.Accept(resource);
+            }
 
             BaseClass = baseClassGenerator.BaseClassTypeName;
 
@@ -126,7 +132,10 @@ namespace Spark.Ruby.Compiler
                 // [SparkView] attribute
                 source.AppendLine("[global::Spark.SparkViewAttribute(");
                 if (TargetNamespace != null)
-                    source.AppendFormat("    TargetNamespace=\"{0}\",", TargetNamespace).AppendLine();
+                {
+                    source.AppendFormat("    TargetNamespace=\"{0}\",", this.TargetNamespace).AppendLine();
+                }
+
                 source.AppendLine("    Templates = new string[] {");
                 source.Append("      ").AppendLine(string.Join(",\r\n      ",
                                                                Descriptor.Templates.Select(

--- a/src/Spark.Ruby/RubyLanguageFactory.cs
+++ b/src/Spark.Ruby/RubyLanguageFactory.cs
@@ -22,6 +22,7 @@ namespace Spark.Ruby
     {
 
         private RubyEngineManager _RubyEngineManager;
+
         public RubyEngineManager RubyEngineManager
         {
             get
@@ -52,12 +53,12 @@ namespace Spark.Ruby
             viewCompiler.BaseClass = pageBaseType;
             viewCompiler.Descriptor = descriptor;
             viewCompiler.Debug = engine.Settings.Debug;
-			viewCompiler.NullBehaviour = engine.Settings.NullBehaviour;
-			viewCompiler.UseAssemblies = engine.Settings.UseAssemblies;
+            viewCompiler.NullBehaviour = engine.Settings.NullBehaviour;
+            viewCompiler.UseAssemblies = engine.Settings.UseAssemblies;
             viewCompiler.UseNamespaces = engine.Settings.UseNamespaces;
+
             return viewCompiler;
         }
-
 
         public override void InstanceCreated(ViewCompiler compiler, ISparkView view)
         {

--- a/src/Spark.Tests/Bindings/BindingExpansionVisitorTester.cs
+++ b/src/Spark.Tests/Bindings/BindingExpansionVisitorTester.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 
 using Spark.Bindings;
@@ -28,7 +26,7 @@ namespace Spark.Tests.Bindings
         [Test]
         public void CallVisitorToProcessNodes()
         {
-            var nodes = new Node[] { new ElementNode("hello", new AttributeNode[0], true) };
+            var nodes = new Node[] { new ElementNode("hello", Array.Empty<AttributeNode>(), true) };
             _visitor.Accept(nodes);
             Assert.That(_visitor.Nodes.Count, Is.EqualTo(1));
             Assert.That(_visitor.Nodes[0], Is.SameAs(nodes[0]));

--- a/src/Spark.Tests/CompiledViewHolderTester.cs
+++ b/src/Spark.Tests/CompiledViewHolderTester.cs
@@ -40,7 +40,7 @@ namespace Spark.Tests
         }
 
         [Test]
-        public void LookupNonExistantReturnsNull()
+        public void LookupNonExistentReturnsNull()
         {
             var key = BuildKey(Path.Combine("c", "v"), Path.Combine("shared", "m"));
             var entry = holder.Lookup(key);

--- a/src/Spark.Web.Mvc.Pdf.Tests/PdfViewResultTests.cs
+++ b/src/Spark.Web.Mvc.Pdf.Tests/PdfViewResultTests.cs
@@ -81,6 +81,7 @@ namespace Spark.Web.Mvc.Pdf.Tests
                          {
                              ViewEngineCollection = new ViewEngineCollection(new[] { factory })
                          };
+
             result.ExecuteResult(controllerContext);
 
             Assert.That(stream.Length, Is.Not.EqualTo(0));

--- a/src/Spark.Web.Mvc.Python/PythonLanguageFactoryWithExtensions.cs
+++ b/src/Spark.Web.Mvc.Python/PythonLanguageFactoryWithExtensions.cs
@@ -54,8 +54,7 @@ namespace Spark.Web.Mvc.Python
                 // need to load the assembly into the runtime domain
                 // before any scripts are created in order for the extension
                 // methods to be "seen" on the dynamic type.
-                PythonEngineManager.ScriptEngine.Runtime.LoadAssembly(
-                    typeof (PythonLanguageFactoryWithExtensions).Assembly);
+                PythonEngineManager.ScriptEngine.Runtime.LoadAssembly(typeof (PythonLanguageFactoryWithExtensions).Assembly);
             }
         }
     }

--- a/src/Spark.Web.Mvc.Ruby.Tests/HtmlHelperExtensionsTester.cs
+++ b/src/Spark.Web.Mvc.Ruby.Tests/HtmlHelperExtensionsTester.cs
@@ -31,12 +31,11 @@ namespace Spark.Web.Mvc.Ruby.Tests
     {
         public class StubHttpContext : HttpContextBase
         {
-            public override Cache Cache { get { return null; } }
+            public override Cache Cache => null;
         }
 
         public class StubController : Controller
         {
-
         }
 
         [Test]
@@ -44,11 +43,11 @@ namespace Spark.Web.Mvc.Ruby.Tests
         {
             var languageFactory = new RubyLanguageFactoryWithExtensions();
             var header = languageFactory.BuildScriptHeader(languageFactory.GetType().Assembly);
+
             Assert.That(header.Contains("ActionLink"));
             Assert.That(header.Contains("Password"));
             Assert.That(header.Contains("RenderPartial"));
         }
-
 
         private static ViewContext CompileView(string viewContents)
         {
@@ -70,6 +69,7 @@ namespace Spark.Web.Mvc.Ruby.Tests
             var controllerContext = new ControllerContext(httpContext, routeData, controller);
 
             var result = viewEngine.FindPartialView(controllerContext, "index", false);
+
             return new ViewContext(controllerContext, result.View, new ViewDataDictionary(), new TempDataDictionary(), new StringWriter());
         }
 

--- a/src/Spark.Web.Mvc.Tests/DescriptorBuildingTester.cs
+++ b/src/Spark.Web.Mvc.Tests/DescriptorBuildingTester.cs
@@ -56,8 +56,12 @@ namespace Spark.Web.Mvc.Tests
             params string[] templates)
         {
             Assert.AreEqual(templates.Length, descriptor.Templates.Count, "Descriptor template count must match");
+
             for (var index = 0; index != templates.Length; ++index)
+            {
                 Assert.AreEqual(templates[index], descriptor.Templates[index]);
+            }
+
             Assert.AreEqual(0, searchedLocations.Count, "searchedLocations must be empty");
         }
 
@@ -69,8 +73,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark");
         }
 
@@ -82,8 +88,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.shade");
         }
 
@@ -96,8 +104,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark",
                 @"Layouts\Application.spark");
         }
@@ -111,8 +121,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.shade",
                 @"Layouts\Application.shade");
         }
@@ -127,8 +139,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark",
                 @"Layouts\Home.spark");
         }
@@ -143,8 +157,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.shade",
                 @"Layouts\Home.shade");
         }
@@ -160,8 +176,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", "Site", true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark",
                 @"Layouts\Site.spark");
         }
@@ -177,8 +195,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", "Site", true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.shade",
                 @"Layouts\Site.shade");
         }
@@ -195,8 +215,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, false, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark");
         }
 
@@ -212,8 +234,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, false, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.shade");
         }
 
@@ -227,8 +251,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark",
                 @"Layouts\Application.spark");
         }
@@ -243,8 +269,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.shade",
                 @"Layouts\Application.shade");
         }
@@ -260,8 +288,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.spark",
                 @"Layouts\Application.spark");
         }
@@ -277,8 +307,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.shade",
                 @"Layouts\Application.shade");
         }
@@ -293,8 +325,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.spark",
                 @"Layouts\Application.spark");
         }
@@ -309,8 +343,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.shade",
                 @"Layouts\Application.shade");
         }
@@ -327,8 +363,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.spark",
                 @"Admin\Layouts\Application.spark");
         }
@@ -345,8 +383,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.shade",
                 @"Admin\Layouts\Application.shade");
         }
@@ -364,8 +404,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", "Site", true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.spark",
                 @"Admin\Layouts\Site.spark");
         }
@@ -383,8 +425,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", "Site", true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.shade",
                 @"Admin\Layouts\Site.shade");
         }
@@ -404,8 +448,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, false, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Admin\Home\Index.spark");
         }
 
@@ -422,8 +468,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark",
                 @"Layouts\Green.spark",
                 @"Layouts\Red.spark",
@@ -443,8 +491,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", "Red", true, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark",
                 @"Layouts\Red.spark",
                 @"Layouts\Blue.spark");
@@ -463,8 +513,10 @@ namespace Spark.Web.Mvc.Tests
 
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, false, searchedLocations);
+
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.spark");
         }
 
@@ -498,7 +550,7 @@ namespace Spark.Web.Mvc.Tests
             var param3 = new BuildDescriptorParams("a", "c", "d", "e", false, Dict(new[] { "beta" }));
             var param4 = new BuildDescriptorParams("a", "c", "d", "e", false, Dict(new[] { "beta", "alpha" }));
             var param5 = new BuildDescriptorParams("a", "c", "d", "e", false, Dict(null));
-            var param6 = new BuildDescriptorParams("a", "c", "d", "e", false, Dict(new string[0]));
+            var param6 = new BuildDescriptorParams("a", "c", "d", "e", false, Dict(Array.Empty<string>()));
             var param7 = new BuildDescriptorParams("a", "c", "d", "e", false, Dict(new[] { "alpha", "beta" }));
 
             Assert.That(param1, Is.Not.EqualTo(param2));
@@ -534,7 +586,8 @@ namespace Spark.Web.Mvc.Tests
             var searchedLocations = new List<string>();
             var result = _factory.CreateDescriptor(_controllerContext, "Index", null, true, searchedLocations);
             AssertDescriptorTemplates(
-                result, searchedLocations,
+                result,
+                searchedLocations,
                 @"Home\Index.en-us.spark",
                 @"Layouts\Application.en.spark");
         }
@@ -553,9 +606,9 @@ namespace Spark.Web.Mvc.Tests
             public override IDictionary<string, object> GetExtraParameters(ControllerContext controllerContext)
             {
                 return new Dictionary<string, object>
-                           {
-                               {"language", Convert.ToString(controllerContext.RouteData.Values["language"])}
-                           };
+                {
+                    { "language", Convert.ToString(controllerContext.RouteData.Values["language"]) }
+                };
             }
 
             protected override IEnumerable<string> PotentialViewLocations(string controllerName, string viewName, IDictionary<string, object> extra)
@@ -584,7 +637,9 @@ namespace Spark.Web.Mvc.Tests
                     {
                         yield return Path.ChangeExtension(location, region + ".spark");
                         if (slashPos != -1)
+                        {
                             yield return Path.ChangeExtension(location, language + ".spark");
+                        }
                     }
                     yield return location;
                 }
@@ -612,7 +667,6 @@ namespace Spark.Web.Mvc.Tests
             var none = builder.ParseUseMaster(new Position(new SourceContext("  x <use etc=''/> <using master=\"def\"/> y ")));
             var g = builder.ParseUseMaster(new Position(new SourceContext("-<use master=\"g\"/>-<use master=\"h\"/>-")));
 
-
             Assert.That(a.Value, Is.EqualTo("a"));
             Assert.That(b.Value, Is.EqualTo("b"));
             Assert.That(c.Value, Is.EqualTo("c"));
@@ -632,7 +686,6 @@ namespace Spark.Web.Mvc.Tests
             var def = builder.ParseUseMaster(new Position(new SourceContext("  x <s:use etc=''/> <s:use master=\"def\"/> y ")));
             var none = builder.ParseUseMaster(new Position(new SourceContext("  x <s:use etc=''/> <using master=\"def\"/> y ")));
             var g = builder.ParseUseMaster(new Position(new SourceContext("-<s:use master=\"g\"/>-<s:use master=\"h\"/>-")));
-
 
             Assert.That(a.Value, Is.EqualTo("a"));
             Assert.That(b.Value, Is.EqualTo("b"));

--- a/src/Spark.Web.Mvc.Tests/SparkBatchCompilerTester.cs
+++ b/src/Spark.Web.Mvc.Tests/SparkBatchCompilerTester.cs
@@ -49,7 +49,6 @@ namespace Spark.Web.Mvc.Tests
                 .For<StubController>().Layout("layout").Include("Index").Include("List.spark")
                 .For<StubController>().Layout("ajax").Include("_Widget");
 
-
             var assembly = _factory.Precompile(batch);
 
             Assert.IsNotNull(assembly);
@@ -60,9 +59,10 @@ namespace Spark.Web.Mvc.Tests
         public void CanHandleCSharpV3SyntaxWhenLoadedInAppDomainWithoutConfig()
         {
             var appDomainSetup = new AppDomainSetup
-                                    {
-										ApplicationBase = Assembly.GetExecutingAssembly().GetCodeBaseDirectory()
-                                    };
+            {
+                ApplicationBase = Assembly.GetExecutingAssembly().GetCodeBaseDirectory()
+            };
+
             AppDomain sandbox = null;
             try
             {
@@ -134,8 +134,11 @@ namespace Spark.Web.Mvc.Tests
             var batch = new SparkBatchDescriptor();
 
             batch
-                .For<StubController>().Layout("layout").Layout("alternate").Include("Index").Include("List.spark");
-
+                .For<StubController>()
+                .Layout("layout")
+                .Layout("alternate")
+                .Include("Index")
+                .Include("List.spark");
 
             var assembly = _factory.Precompile(batch);
 
@@ -173,28 +176,29 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void FileWithoutSparkExtensionAreIgnored()
         {
-            _factory.ViewFolder = new InMemoryViewFolder
-                                      {
-                                          {string.Format("Stub{0}Index.spark", Path.DirectorySeparatorChar), "<p>index</p>"},
-                                          {string.Format("Stub{0}Helper.cs", Path.DirectorySeparatorChar), "// this is a code file"},
-                                          {string.Format("Layouts{0}Stub.spark", Path.DirectorySeparatorChar), "<p>layout</p><use:view/>"},
-                                      };
+            var viewFolder = new InMemoryViewFolder
+            {
+                { string.Format("Stub{0}Index.spark", Path.DirectorySeparatorChar), "<p>index</p>" },
+                { string.Format("Stub{0}Helper.cs", Path.DirectorySeparatorChar), "// this is a code file" },
+                { string.Format("Layouts{0}Stub.spark", Path.DirectorySeparatorChar), "<p>layout</p><use:view/>" },
+            };
             var batch = new SparkBatchDescriptor();
             batch.For<StubController>();
+
             var descriptors = _factory.CreateDescriptors(batch);
+
             Assert.AreEqual(1, descriptors.Count);
             Assert.AreEqual(2, descriptors[0].Templates.Count);
             Assert.AreEqual(string.Format("Stub{0}Index.spark", Path.DirectorySeparatorChar), descriptors[0].Templates[0]);
             Assert.AreEqual(string.Format("Layouts{0}Stub.spark", Path.DirectorySeparatorChar), descriptors[0].Templates[1]);
         }
-
     }
 
     public static class FooExtensions
     {
         public static string FooFor<T>(this SparkView view, Expression<Action<T>> action)
         {
-            return string.Format("Foo on lambda expression {0}", action);
+            return $"Foo on lambda expression {action}";
         }
     }
 
@@ -209,9 +213,10 @@ namespace Spark.Web.Mvc.Tests
         /// </remarks>
         public static string GetCodeBaseDirectory(this Assembly assembly)
         {
-            string codeBaseUriString = assembly.CodeBase;
-            var uri = new UriBuilder(codeBaseUriString);
-            string codeBasePath = Uri.UnescapeDataString(uri.Path);
+            var codeBaseUriString = assembly.CodeBase;
+            var uriBuilder = new UriBuilder(codeBaseUriString);
+            var codeBasePath = Uri.UnescapeDataString(uriBuilder.Path);
+            
             return Path.GetDirectoryName(codeBasePath);
         }
     }

--- a/src/Spark.Web.Mvc.Tests/SparkViewFactoryTester.cs
+++ b/src/Spark.Web.Mvc.Tests/SparkViewFactoryTester.cs
@@ -27,7 +27,6 @@ using Spark.FileSystem;
 using Spark.Web.Mvc.Tests.Controllers;
 using Spark.Web.Mvc.Tests.Models;
 
-
 namespace Spark.Web.Mvc.Tests
 {
     [TestFixture, Category("SparkViewEngine")]
@@ -110,6 +109,7 @@ namespace Spark.Web.Mvc.Tests
         private ViewContext MakeViewContext(string viewName)
         {
             var result = factory.FindView(controllerContext, viewName, null);
+
             return new ViewContext(controllerContext, result.View, new ViewDataDictionary(), new TempDataDictionary(), output);
         }
 
@@ -158,11 +158,11 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void CaptureNamedContent()
         {
-
             FindViewAndRender("namedcontent", "layout");
 
             //mocks.VerifyAll();
             var content = output.ToString();
+
             Assert.That(content.Contains("<p>main content</p>"));
             Assert.That(content.Contains("<p>this is the header</p>"));
             Assert.That(content.Contains("<p>footer part one</p>"));
@@ -179,6 +179,7 @@ namespace Spark.Web.Mvc.Tests
 
             //mocks.VerifyAll();
             var content = output.ToString();
+
             Assert.That(content.Contains("<h1>Hello world</h1>"));
             Assert.That(content.Contains("<p>foo</p>"));
             Assert.That(content.Contains("<p>bar</p>"));
@@ -188,29 +189,26 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void ForEachTest()
         {
-
-
             FindViewAndRender("foreach", null);
 
             //mocks.VerifyAll();
 
             var content = output.ToString();
+
             Assert.That(content.Contains(@"<li class=""odd"">1: foo</li>"));
             Assert.That(content.Contains(@"<li class=""even"">2: bar</li>"));
             Assert.That(content.Contains(@"<li class=""odd"">3: baaz</li>"));
         }
 
-
         [Test]
         public void GlobalSetTest()
         {
-
-
             FindViewAndRender("globalset", null);
 
             //mocks.VerifyAll();
 
             var content = output.ToString();
+
             Assert.That(content.Contains("<p>default: Global set test</p>"));
             Assert.That(content.Contains("<p>7==7</p>"));
         }
@@ -218,11 +216,11 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void HtmlEncodeFunctionH()
         {
-
             FindViewAndRender("html-encode-function-h");
             //mocks.VerifyAll();
 
             var content = output.ToString().Replace(" ", "").Replace("\r", "").Replace("\n", "");
+
             Assert.AreEqual("<p>&lt;p&gt;&amp;lt;&amp;gt;&lt;/p&gt;</p>", content);
         }
 
@@ -275,9 +273,7 @@ namespace Spark.Web.Mvc.Tests
             routeData.Values["controller"] = "Foo";
             routeData.Values["action"] = "NotBaaz";
 
-
             var descriptor = factory.CreateDescriptor(controllerContext, "Baaz", null, true, null);
-
 
             Assert.AreEqual(1, descriptor.Templates.Count);
             Assert.AreEqual(string.Format("Foo{0}Baaz.spark", Path.DirectorySeparatorChar), descriptor.Templates[0]);
@@ -301,19 +297,18 @@ namespace Spark.Web.Mvc.Tests
             var descriptor = factory.CreateDescriptor(controllerContext, "Baaz", null, true, null);
 
             Assert.AreEqual(2, descriptor.Templates.Count);
-            Assert.AreEqual(string.Format("Foo{0}Baaz.spark", Path.DirectorySeparatorChar), descriptor.Templates[0]);
-            Assert.AreEqual(string.Format("Shared{0}Foo.spark", Path.DirectorySeparatorChar), descriptor.Templates[1]);
+            Assert.AreEqual($"Foo{Path.DirectorySeparatorChar}Baaz.spark", descriptor.Templates[0]);
+            Assert.AreEqual($"Shared{Path.DirectorySeparatorChar}Foo.spark", descriptor.Templates[1]);
         }
 
         [Test]
         public void MasterTest()
         {
-
-
             FindViewAndRender("childview", "layout");
 
             //mocks.VerifyAll();
             var content = output.ToString();
+
             Assert.That(content.Contains("<title>Standalone Index View</title>"));
             Assert.That(content.Contains("<h1>Standalone Index View</h1>"));
             Assert.That(content.Contains("<p>no header by default</p>"));
@@ -323,35 +318,35 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void NullViewDataIsSafe()
         {
-
             FindViewAndRender("viewdatanull", null);
             //mocks.VerifyAll();
 
             var content = output.ToString();
+
             Assert.That(content.Contains("<p>nothing</p>"));
         }
 
         [Test]
         public void RenderPartialOrderCorrect()
         {
-
             FindViewAndRender("renderpartial-ordercorrect", "ajax");
             //mocks.VerifyAll();
 
             var content = output.ToString();
-            ContainsInOrder(content,
-                            "<p>one</p>",
-                            "<p>two</p>",
-                            "<p>three</p>");
+            ContainsInOrder(
+                content,
+                "<p>one</p>",
+                "<p>two</p>",
+                "<p>three</p>");
         }
 
         [Test]
         public void RenderPlainView()
         {
-
-
             var viewContext = MakeViewContext("index");
+            
             var viewEngineResult = factory.FindView(controllerContext, "index", null);
+            
             viewEngineResult.View.Render(viewContext, output);
 
             //mocks.VerifyAll();
@@ -377,16 +372,14 @@ namespace Spark.Web.Mvc.Tests
             Assert.AreEqual("Spark.Web.Mvc.Tests.Controllers", descriptor.TargetNamespace);
         }
 
-
         [Test]
         public void UsingHtmlHelper()
         {
-
-
             FindViewAndRender("helpers", null);
 
             //mocks.VerifyAll();
             var content = output.ToString();
+
             Assert.That(content.Contains("<p><a href=\"/Home/Sort\">Click me</a></p>"));
             Assert.That(content.Contains("<p>foo&gt;bar</p>"));
         }
@@ -394,11 +387,11 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void UsingNamespace()
         {
-
             FindViewAndRender("usingnamespace");
 
             //mocks.VerifyAll();
             var content = output.ToString();
+
             Assert.That(content.Contains("<p>Foo</p>"));
             Assert.That(content.Contains("<p>Bar</p>"));
             Assert.That(content.Contains("<p>Hello</p>"));
@@ -407,12 +400,11 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void UsingPartialFile()
         {
-
-
             FindViewAndRender("usingpartial", null);
 
             //mocks.VerifyAll();
             var content = output.ToString();
+
             Assert.That(content.Contains("<li>Partial where x=\"zero\"</li>"));
             Assert.That(content.Contains("<li>Partial where x=\"one\"</li>"));
             Assert.That(content.Contains("<li>Partial where x=\"two\"</li>"));
@@ -423,25 +415,23 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void UsingPartialFileImplicit()
         {
-
-
             FindViewAndRender("usingpartialimplicit", null);
 
             //mocks.VerifyAll();
             var content = output.ToString();
+
             Assert.That(content.Contains("<li class=\"odd\">one</li>"));
             Assert.That(content.Contains("<li class=\"even\">two</li>"));
         }
 
-
         [Test]
         public void ViewDataWithModel()
         {
-
             FindViewAndRender("viewdatamodel", new Comment { Text = "Hello" });
             //mocks.VerifyAll();
 
             var content = output.ToString();
+
             Assert.That(content.Contains("<p>Hello</p>"));
         }
 
@@ -484,29 +474,27 @@ namespace Spark.Web.Mvc.Tests
             Assert.AreSame(viewActivatorFactory, viewFactory.ViewActivatorFactory);
         }
 
-
         [Test]
         public void EvalWithViewDataModel()
         {
-
             FindViewAndRender("EvalWithViewDataModel", new Comment { Text = "Hello" });
             //mocks.VerifyAll();
 
             var content = output.ToString();
+
             Assert.That(content.Contains("<p>Hello</p>"));
         }
 
         [Test]
         public void EvalWithAnonModel()
         {
-
             FindViewAndRender("EvalWithAnonModel", new { Foo = 42, Bar = new Comment { Text = "Hello" } });
             //mocks.VerifyAll();
 
             var content = output.ToString();
+
             Assert.That(content.Contains("<p>42 Hello</p>"));
         }
-
 
         public class ScopedCulture : IDisposable
         {
@@ -532,6 +520,7 @@ namespace Spark.Web.Mvc.Tests
                 FindViewAndRender("EvalWithFormatString", new { Cost = 134567.89, terms = new { due = new DateTime(1971, 10, 14) } });
 
                 var content = output.ToString();
+
                 Assert.That(content.Contains("<p>134,567.89</p>"));
                 Assert.That(content.Contains("<p>1971/10/14</p>"));
             }
@@ -540,7 +529,6 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void RenderPartialSharesState()
         {
-
             FindViewAndRender("RenderPartialSharesState");
             //mocks.VerifyAll();
 
@@ -558,6 +546,7 @@ namespace Spark.Web.Mvc.Tests
                             "<li>two</li>",
                             "</ul>",
                             "alphabetagammadelta");
+
             Assert.IsFalse(content.Contains("foo2"));
             Assert.IsFalse(content.Contains("bar4"));
             Assert.IsFalse(content.Contains("quux7"));
@@ -566,9 +555,10 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void CanLocateViewInArea()
         {
-
             controllerContext.RouteData.DataTokens.Add("area", "admin");
+            
             var result = factory.FindView(controllerContext, "index", null);
+
             var viewContext = new ViewContext(controllerContext, result.View, new ViewDataDictionary(), new TempDataDictionary(), output);
             viewContext.View.Render(viewContext, output);
             //mocks.VerifyAll();
@@ -579,40 +569,46 @@ namespace Spark.Web.Mvc.Tests
         [Test]
         public void CanLocateViewInAreaWithLayout()
         {
-
             controllerContext.RouteData.DataTokens.Add("area", "admin");
+            
             var result = factory.FindView(controllerContext, "index", "layout");
+            
             var viewContext = new ViewContext(controllerContext, result.View, new ViewDataDictionary(), new TempDataDictionary(), output);
             viewContext.View.Render(viewContext, output);
             //mocks.VerifyAll();
 
-            ContainsInOrder(output.ToString(),
-                            "<body>",
-                            "<p>default view admin area</p>",
-                            "</body>");
+            ContainsInOrder(
+                output.ToString(),
+                "<body>",
+                "<p>default view admin area</p>",
+                "</body>");
         }
 
         [Test]
         public void CanLocateViewInAreaWithLayoutInArea()
         {
-
             controllerContext.RouteData.DataTokens.Add("area", "admin");
+            
             var result = factory.FindView(controllerContext, "index", "speciallayout");
+            
             var viewContext = new ViewContext(controllerContext, result.View, new ViewDataDictionary(), new TempDataDictionary(), output);
             viewContext.View.Render(viewContext, output);
             //mocks.VerifyAll();
 
-            ContainsInOrder(output.ToString(),
-                            "<body class=\"special\">",
-                            "<p>default view admin area</p>",
-                            "</body>");
+            ContainsInOrder(
+                output.ToString(),
+                "<body class=\"special\">",
+                "<p>default view admin area</p>",
+                "</body>");
         }
 
         [Test]
         public void CanLocatePartialViewInArea()
         {
             controllerContext.RouteData.DataTokens.Add("area", "admin");
+            
             var result = factory.FindPartialView(controllerContext, "index");
+            
             var viewContext = new ViewContext(controllerContext, result.View, new ViewDataDictionary(), new TempDataDictionary(), output);
             viewContext.View.Render(viewContext, output);
             //mocks.VerifyAll();
@@ -630,8 +626,7 @@ namespace Spark.Web.Mvc.Tests
             var viewContext = new ViewContext(controllerContext, result.View, new ViewDataDictionary(), new TempDataDictionary(), output);
             viewContext.View.Render(viewContext, output);
 
-            Assert.That(output.ToString().Replace("\r\n", ""),
-                        Is.EqualTo("<p>alpha</p><p>gamma</p><p>beta</p>"));
+            Assert.That(output.ToString().Replace("\r\n", ""), Is.EqualTo("<p>alpha</p><p>gamma</p><p>beta</p>"));
         }
 
         public class RenderActionControllerFactory : IControllerFactory
@@ -665,16 +660,18 @@ namespace Spark.Web.Mvc.Tests
             FindViewAndRender("ViewContextWriterWillFollowOutputScope");
 
             var content = output.ToString();
-            ContainsInOrder(content,
-                            "[alpha]",
-                            "[1]",
-                            "[4]",
-                            "[beta]",
-                            "[2]",
-                            "<form",
-                            "[gamma]",
-                            "</form",
-                            "[3]");
+
+            ContainsInOrder(
+                content,
+                "[alpha]",
+                "[1]",
+                "[4]",
+                "[beta]",
+                "[2]",
+                "<form",
+                "[gamma]",
+                "</form",
+                "[3]");
         }
         
         [Test]
@@ -683,12 +680,12 @@ namespace Spark.Web.Mvc.Tests
              FindViewAndRender("AutoencodeIgnoresHtmlHelpers");
 
             var content = output.ToString();
+            
             ContainsInOrder(content,
                             "[1:&lt;p&gt;foo&lt;/p&gt;]",
                             "[2:<p>foo</p>]",
                             "[3:<a ",
                             "[4:<a ");
-
         }
 
         [Test]
@@ -697,9 +694,11 @@ namespace Spark.Web.Mvc.Tests
             FindViewAndRender("AutoencodeIgnoresMacros");
 
             var content = output.ToString();
-            ContainsInOrder(content,
-                            "[1:<p>foo</p>]",
-                            "[2:<p>foo</p>]");
+            
+            ContainsInOrder(
+                content,
+                "[1:<p>foo</p>]",
+                "[2:<p>foo</p>]");
         }
     }
 }

--- a/src/Spark.Web.Mvc/DefaultCacheServiceProvider.cs
+++ b/src/Spark.Web.Mvc/DefaultCacheServiceProvider.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Web.Caching;
 using System.Web.Routing;
 using Spark.Caching;
 

--- a/src/Spark.Web.Mvc/DefaultDescriptorBuilder.cs
+++ b/src/Spark.Web.Mvc/DefaultDescriptorBuilder.cs
@@ -47,7 +47,10 @@ namespace Spark.Web.Mvc
         {
             var extra = new Dictionary<string, object>();
             foreach (var filter in Filters)
+            {
                 filter.ExtraParameters(controllerContext, extra);
+            }
+
             return extra;
         }
 
@@ -138,7 +141,9 @@ namespace Spark.Web.Mvc
                         {
                             var result = useMaster(scan);
                             if (result != null)
+                            {
                                 return result;
+                            }
                         }
                         return null;
                     };
@@ -155,7 +160,10 @@ namespace Spark.Web.Mvc
             var lastTemplate = descriptor.Templates.Last();
             var sourceContext = AbstractSyntaxProvider.CreateSourceContext(lastTemplate, _engine.ViewFolder);
             if (sourceContext == null)
+            {
                 return null;
+            }
+
             var result = ParseUseMaster(new Position(sourceContext));
             return result == null ? null : result.Value;
         }
@@ -174,7 +182,9 @@ namespace Spark.Web.Mvc
             if (searchedLocations != null)
             {
                 foreach (var potentialTemplate in potentialTemplates)
+                {
                     searchedLocations.Add(potentialTemplate);
+                }
             }
             return false;
         }

--- a/src/Spark.Web.Mvc/Install/PrecompileInstaller.cs
+++ b/src/Spark.Web.Mvc/Install/PrecompileInstaller.cs
@@ -51,9 +51,9 @@ namespace Spark.Web.Mvc.Install
                 targetPath = Path.Combine(webBinPath, TargetAssemblyFile);
 
             ISparkSettings settings;
-            if (SettingsInstantiator != null)
+            if (this.SettingsInstantiator != null)
             {
-                settings = SettingsInstantiator();
+                settings = this.SettingsInstantiator();
             }
             else
             {
@@ -82,7 +82,9 @@ namespace Spark.Web.Mvc.Install
 
             // and give the containing installer a change to add entries
             if (DescribeBatch != null)
-                DescribeBatch(this, new DescribeBatchEventArgs {Batch = batch});
+            {
+                this.DescribeBatch(this, new DescribeBatchEventArgs { Batch = batch });
+            }
 
             factory.Precompile(batch);
 

--- a/src/Spark.Web.Mvc/LanguageKit.cs
+++ b/src/Spark.Web.Mvc/LanguageKit.cs
@@ -26,7 +26,9 @@ namespace Spark.Web.Mvc
         public static void Install(IEnumerable<IViewEngine> engines, Func<ControllerContext, string> selector)
         {
             foreach (var factory in engines.OfType<SparkViewFactory>())
+            {
                 Install(factory, selector);
+            }
         }
 
         public class Filter : DescriptorFilterBase
@@ -42,14 +44,18 @@ namespace Spark.Web.Mvc
             {
                 var theme = Convert.ToString(_selector(context));
                 if (!string.IsNullOrEmpty(theme))
+                {
                     extra["language"] = theme;
+                }
             }
 
             public override IEnumerable<string> PotentialLocations(IEnumerable<string> locations, IDictionary<string, object> extra)
             {
                 string languageName;
                 if (!TryGetString(extra, "language", out languageName))
+                {
                     return locations;
+                }
 
                 var prefix = Path.Combine("language", languageName);
                 return locations.Select(path => Path.Combine(prefix, path));
@@ -69,7 +75,9 @@ namespace Spark.Web.Mvc
             {
                 var lang = ParseLanguagePath(path);
                 if (lang == null)
-                    return _viewFolder.HasView(path);
+                {
+                    return this._viewFolder.HasView(path);
+                }
 
                 return PathVariations(lang).Any(x => _viewFolder.HasView(x));
             }
@@ -78,7 +86,9 @@ namespace Spark.Web.Mvc
             {
                 var lang = ParseLanguagePath(path);
                 if (lang == null)
-                    return _viewFolder.GetViewSource(path);
+                {
+                    return this._viewFolder.GetViewSource(path);
+                }
 
                 var detected = PathVariations(lang).First(x => _viewFolder.HasView(x));
                 return _viewFolder.GetViewSource(detected ?? lang.Path);
@@ -88,7 +98,9 @@ namespace Spark.Web.Mvc
             {
                 var lang = ParseLanguagePath(path);
                 if (lang == null)
-                    return _viewFolder.ListViews(path);
+                {
+                    return this._viewFolder.ListViews(path);
+                }
 
                 var languageExtension = "." + lang.Language + ".spark";
                 var shortLanguageExtension = lang.ShortLanguage == null ? null : "." + lang.ShortLanguage + ".spark";
@@ -97,10 +109,9 @@ namespace Spark.Web.Mvc
 
                 var adjustedViews = actualViews.Select(
                     actualPath =>
-                    AlterPath(actualPath, languageExtension, lang.Prefix) ??
-                    AlterPath(actualPath, shortLanguageExtension, lang.Prefix) ??
-                    Path.Combine(lang.Prefix, actualPath)
-                    );
+                        AlterPath(actualPath, languageExtension, lang.Prefix) ??
+                        AlterPath(actualPath, shortLanguageExtension, lang.Prefix) ??
+                        Path.Combine(lang.Prefix, actualPath));
 
                 return adjustedViews.Distinct().ToList();
             }
@@ -112,6 +123,7 @@ namespace Spark.Web.Mvc
                 {
                     return null;
                 }
+
                 return Path.Combine(prefix, path.Substring(0, path.Length - extension.Length) + ".spark");
             }
 
@@ -129,7 +141,9 @@ namespace Spark.Web.Mvc
 
                 var slashPos = path.IndexOfAny(new[] { '/', Path.DirectorySeparatorChar }, language.Length + 1);
                 if (slashPos == -1)
+                {
                     return null;
+                }
 
                 var lang = new LanguagePath
                                {
@@ -140,7 +154,9 @@ namespace Spark.Web.Mvc
 
                 var dashPos = lang.Language.IndexOf('-');
                 if (dashPos != -1)
+                {
                     lang.ShortLanguage = lang.Language.Substring(0, dashPos);
+                }
 
                 return lang;
             }
@@ -150,18 +166,18 @@ namespace Spark.Web.Mvc
                 if (string.IsNullOrEmpty(lang.ShortLanguage))
                 {
                     return new[]
-                               {
-                                   Path.ChangeExtension(lang.Path, lang.Language + ".spark"),
-                                   lang.Path
-                               };
+                    {
+                        Path.ChangeExtension(lang.Path, lang.Language + ".spark"),
+                        lang.Path
+                    };
                 }
 
                 return new[]
-                           {
-                               Path.ChangeExtension(lang.Path, lang.Language + ".spark"),
-                               Path.ChangeExtension(lang.Path, lang.ShortLanguage + ".spark"),
-                               lang.Path
-                           };
+                {
+                    Path.ChangeExtension(lang.Path, lang.Language + ".spark"),
+                    Path.ChangeExtension(lang.Path, lang.ShortLanguage + ".spark"),
+                    lang.Path
+                };
             }
         }
 

--- a/src/Spark.Web.Mvc/SparkView.cs
+++ b/src/Spark.Web.Mvc/SparkView.cs
@@ -26,31 +26,18 @@ namespace Spark.Web.Mvc
         private ViewDataDictionary _viewData;
         private ViewContext _viewContext;
     	private dynamic _viewBag;
-
-
-        public TempDataDictionary TempData
-        {
-            get { return ViewContext.TempData; }
-        }
+        
+        public TempDataDictionary TempData => ViewContext.TempData;
 
         public HtmlHelper Html { get; set; }
         public UrlHelper Url { get; set; }
         public AjaxHelper Ajax { get; set; }
 
-        public HttpContextBase Context
-        {
-            get { return ViewContext.HttpContext; }
-        }
+        public HttpContextBase Context => ViewContext.HttpContext;
 
-        public HttpRequestBase Request
-        {
-            get { return ViewContext.HttpContext.Request; }
-        }
+        public HttpRequestBase Request => ViewContext.HttpContext.Request;
 
-        public HttpResponseBase Response
-        {
-            get { return ViewContext.HttpContext.Response; }
-        }
+        public HttpResponseBase Response => ViewContext.HttpContext.Response;
 
         public IResourcePathManager ResourcePathManager { get; set; }
 
@@ -196,12 +183,14 @@ namespace Spark.Web.Mvc
 
             Content.Clear();
         }
-
-
+        
         public string H(object value)
         {
-            if (value is MvcHtmlString)
-                return H((MvcHtmlString)value);
+            if (value is MvcHtmlString htmlString)
+            {
+                return H(htmlString);
+            }
+            
             return Html.Encode(value);
         }
 
@@ -223,8 +212,6 @@ namespace Spark.Web.Mvc
         {
             return ViewData.Eval(expression, format);
         }
-
-
     }
 
     public abstract class SparkView<TModel> : SparkView
@@ -233,10 +220,7 @@ namespace Spark.Web.Mvc
         private HtmlHelper<TModel> _htmlHelper;
         private AjaxHelper<TModel> _ajaxHelper;
 
-        public TModel Model
-        {
-            get { return ViewData.Model; }
-        }
+        public TModel Model => ViewData.Model;
 
         public new ViewDataDictionary<TModel> ViewData
         {
@@ -251,7 +235,7 @@ namespace Spark.Web.Mvc
 
         public new HtmlHelper<TModel> Html
         {
-            get { return _htmlHelper; }
+            get => _htmlHelper;
             set
             {
                 _htmlHelper = value; 
@@ -261,7 +245,7 @@ namespace Spark.Web.Mvc
 
         public new AjaxHelper<TModel> Ajax
         {
-            get { return _ajaxHelper; }
+            get => _ajaxHelper;
             set
             {
                 _ajaxHelper = value;

--- a/src/Spark.Web.Mvc/SparkViewFactory.cs
+++ b/src/Spark.Web.Mvc/SparkViewFactory.cs
@@ -168,6 +168,7 @@ namespace Spark.Web.Mvc
                 {
                     return BuildResult(controllerContext.RequestContext, entry);
                 }
+
                 return _cacheMissResult;
             }
 
@@ -176,10 +177,14 @@ namespace Spark.Web.Mvc
                 searchedLocations);
 
             if (descriptor == null)
+            {
                 return new ViewEngineResult(searchedLocations);
+            }
 
             entry = Engine.CreateEntry(descriptor);
+            
             SetCacheValue(descriptorParams, entry);
+
             return BuildResult(controllerContext.RequestContext, entry);
         }
 
@@ -243,9 +248,9 @@ namespace Spark.Web.Mvc
 
             if (descriptor == null)
             {
-                throw new CompilerException("Unable to find templates at " +
-                                            string.Join(", ", searchedLocations.ToArray()));
+                throw new CompilerException($"Unable to find templates at {string.Join(", ", searchedLocations.ToArray())}");
             }
+
             return descriptor;
         }
 
@@ -258,8 +263,12 @@ namespace Spark.Web.Mvc
         public List<SparkViewDescriptor> CreateDescriptors(SparkBatchDescriptor batch)
         {
             var descriptors = new List<SparkViewDescriptor>();
+            
             foreach (var entry in batch.Entries)
+            {
                 descriptors.AddRange(CreateDescriptors(entry));
+            }
+
             return descriptors;
         }
 
@@ -270,9 +279,13 @@ namespace Spark.Web.Mvc
             var controllerName = RemoveSuffix(entry.ControllerType.Name, "Controller");
 
             var viewNames = new List<string>();
+
             var includeViews = entry.IncludeViews;
+
             if (includeViews.Count == 0)
+            {
                 includeViews = new[] { "*" };
+            }
 
             foreach (var include in includeViews)
             {
@@ -281,23 +294,31 @@ namespace Spark.Web.Mvc
                     foreach (var fileName in ViewFolder.ListViews(controllerName))
                     {
                         if (!string.Equals(Path.GetExtension(fileName), ".spark", StringComparison.InvariantCultureIgnoreCase))
+                        {
                             continue;
+                        }
 
                         var potentialMatch = Path.GetFileNameWithoutExtension(fileName);
                         if (!TestMatch(potentialMatch, include))
+                        {
                             continue;
+                        }
 
                         var isExcluded = false;
                         foreach (var exclude in entry.ExcludeViews)
                         {
                             if (!TestMatch(potentialMatch, RemoveSuffix(exclude, ".spark")))
+                            {
                                 continue;
+                            }
 
                             isExcluded = true;
                             break;
                         }
                         if (!isExcluded)
+                        {
                             viewNames.Add(potentialMatch);
+                        }
                     }
                 }
                 else
@@ -349,18 +370,18 @@ namespace Spark.Web.Mvc
             }
 
             // otherwise the only thing that's supported is "starts with"
-            return potentialMatch.StartsWith(pattern.Substring(0, pattern.Length - 1),
-                                             StringComparison.InvariantCultureIgnoreCase);
+            return potentialMatch.StartsWith(pattern.Substring(0, pattern.Length - 1), StringComparison.InvariantCultureIgnoreCase);
         }
 
         private static string RemoveSuffix(string value, string suffix)
         {
             if (value.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase))
+            {
                 return value.Substring(0, value.Length - suffix.Length);
+            }
+
             return value;
         }
-
-
 
         #region IViewEngine Members
 
@@ -396,8 +417,8 @@ namespace Spark.Web.Mvc
 
         IViewFolder IViewFolderContainer.ViewFolder
         {
-            get { return ViewFolder; }
-            set { ViewFolder = value; }
+            get => Engine.ViewFolder;
+            set => Engine.ViewFolder = value;
         }
 
         #endregion

--- a/src/Spark.Web.Mvc/Wrappers/ViewFolderWrapper.cs
+++ b/src/Spark.Web.Mvc/Wrappers/ViewFolderWrapper.cs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Spark.FileSystem;
 
 namespace Spark.Web.Mvc.Wrappers

--- a/src/Spark.Web.Tests/BatchCompilationTester.cs
+++ b/src/Spark.Web.Tests/BatchCompilationTester.cs
@@ -63,11 +63,13 @@ namespace Spark
             var entry0 = engine.GetEntry(descriptors[0]);
             var view0 = entry0.CreateInstance();
             var result0 = view0.RenderView();
+
             Assert.AreEqual("<p>Hello world</p>", result0);
 
             var entry1 = engine.GetEntry(descriptors[1]);
             var view1 = entry1.CreateInstance();
             var result1 = view1.RenderView();
+
             Assert.AreEqual("<ol><li>one</li><li>two</li></ol>", result1);
 
             Assert.AreSame(view0.GetType().Assembly, view1.GetType().Assembly);
@@ -117,18 +119,23 @@ namespace Spark
         public void LoadCompiledViews()
         {
             var descriptors = engine.LoadBatchCompilation(GetType().Assembly);
+
             Assert.AreEqual(2, descriptors.Count);
 
-            var view1 = engine.CreateInstance(new SparkViewDescriptor()
-                                      .SetTargetNamespace("Spark.Tests.Precompiled")
-                                      .AddTemplate(Path.Combine("Foo","Bar.spark"))
-                                      .AddTemplate(Path.Combine("Shared","Quux.spark")));
+            var view1 = engine.CreateInstance(
+                new SparkViewDescriptor()
+                    .SetTargetNamespace("Spark.Tests.Precompiled")
+                    .AddTemplate(Path.Combine("Foo", "Bar.spark"))
+                    .AddTemplate(Path.Combine("Shared", "Quux.spark")));
+
             Assert.AreEqual(typeof(View1), view1.GetType());
 
-            var view2 = engine.CreateInstance(new SparkViewDescriptor()
-                                      .SetTargetNamespace("Spark.Tests.Precompiled")
-                                      .AddTemplate(Path.Combine("Hello","World.spark"))
-                                      .AddTemplate(Path.Combine("Shared","Default.spark")));
+            var view2 = engine.CreateInstance(
+                new SparkViewDescriptor()
+                    .SetTargetNamespace("Spark.Tests.Precompiled")
+                    .AddTemplate(Path.Combine("Hello", "World.spark"))
+                    .AddTemplate(Path.Combine("Shared", "Default.spark")));
+
             Assert.AreEqual(typeof(View2), view2.GetType());
         }
 
@@ -143,9 +150,8 @@ namespace Spark
             var moduleBuilder = assemblyBuilder.DefineDynamicModule("DynamicModule", "DynamicAssembly.dll");
             var type = moduleBuilder.DefineType("DynamicType", TypeAttributes.Public).CreateType();
             assemblyBuilder.Save("DynamicAssembly.dll");
+
             Assert.IsTrue(type.Assembly.IsDynamic());
         }
-
-        
     }
 }

--- a/src/Spark.Web.Tests/Bindings/BindingExecutionTester.cs
+++ b/src/Spark.Web.Tests/Bindings/BindingExecutionTester.cs
@@ -10,7 +10,6 @@ namespace Spark.Bindings
     [TestFixture]
     public class BindingExecutionTester
     {
-
         private InMemoryViewFolder _viewFolder;
         private StubViewFactory _factory;
 
@@ -53,7 +52,6 @@ namespace Spark.Bindings
             var contents = this.Render("index");
             Assert.That(contents, Is.EqualTo(@"<p>world</p>"));
         }
-
 
         [Test]
         public void ElementReplacedWithMacroCall()
@@ -324,13 +322,18 @@ namespace Spark.Bindings
         public void BindingShouldMaintainNewLine()
         {
             this._viewFolder.Add("bindings.xml", @"<bindings><element name='Text'>child::*</element></bindings>");
-            this._viewFolder.Add(Path.Combine("home", "index.spark"), @"
+            this._viewFolder.Add(
+                Path.Combine("home", "index.spark"),
+                @"
 <p>
     <Text>John St</Text>
 </p>");
 
             var contents = this.Render("index");
-            Assert.That(contents, Is.EqualTo(@"
+            Assert.That(
+                contents,
+                Is.EqualTo(
+                    @"
 <p>
     John St
 </p>"));

--- a/src/Spark.Web.Tests/Caching/CacheElementTester.cs
+++ b/src/Spark.Web.Tests/Caching/CacheElementTester.cs
@@ -32,7 +32,6 @@ namespace Spark.Caching
     [TestFixture]
     public class CacheElementTester
     {
-
         private InMemoryViewFolder _viewFolder;
         private StubViewFactory _factory;
         private StubCacheService _cacheService;

--- a/src/Spark.Web.Tests/Compiler/CSharpViewCompilerTester.cs
+++ b/src/Spark.Web.Tests/Compiler/CSharpViewCompilerTester.cs
@@ -72,6 +72,7 @@ namespace Spark.Compiler
             DoCompileView(compiler, new[] { new SendExpressionChunk { Code = "3 + 4" } });
             var instance = compiler.CreateInstance();
             string contents = instance.RenderView();
+
             Assert.AreEqual("7", contents);
         }
 
@@ -112,6 +113,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<ul><li>3</li><li>4</li><li>5</li></ul>", contents);
         }
 
@@ -130,6 +132,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("hello world:8", contents);
         }
 
@@ -143,8 +146,8 @@ namespace Spark.Compiler
                            };
             DoCompileView(compiler, new Chunk[] { new SendLiteralChunk { Text = "Hello" } });
             var instance = compiler.CreateInstance();
-            Assert.AreEqual("Testing.Target.Namespace", instance.GetType().Namespace);
 
+            Assert.AreEqual("Testing.Target.Namespace", instance.GetType().Namespace);
         }
 
 
@@ -152,12 +155,16 @@ namespace Spark.Compiler
         public void ProvideFullException()
         {
             var compiler = new CSharpViewCompiler { BaseClass = "Spark.SparkViewBase" };
-            Assert.That(() =>
-                        DoCompileView(compiler, new Chunk[]
-                                                    {
-                                                        new SendExpressionChunk {Code = "NoSuchVariable"}
-                                                    }),
-                        Throws.TypeOf<BatchCompilerException>());
+
+            Assert.That(
+                () =>
+                    DoCompileView(
+                        compiler,
+                        new Chunk[]
+                        {
+                            new SendExpressionChunk { Code = "NoSuchVariable" }
+                        }),
+                Throws.TypeOf<CodeDomCompilerException>().Or.TypeOf<RoslynCompilerException>());
         }
 
         [Test]
@@ -167,15 +174,19 @@ namespace Spark.Compiler
 
             var trueChunks = new Chunk[] { new SendLiteralChunk { Text = "wastrue" } };
 
-            DoCompileView(compiler, new Chunk[]
-                                    {
-                                        new SendLiteralChunk {Text = "<p>"},
-                                        new LocalVariableChunk{Name="arg", Value="5"},
-                                        new ConditionalChunk{Type=ConditionalType.If, Condition="arg==5", Body=trueChunks},
-                                        new SendLiteralChunk {Text = "</p>"}
-                                    });
+            DoCompileView(
+                compiler,
+                new Chunk[]
+                {
+                    new SendLiteralChunk { Text = "<p>" },
+                    new LocalVariableChunk { Name = "arg", Value = "5" },
+                    new ConditionalChunk { Type = ConditionalType.If, Condition = "arg==5", Body = trueChunks },
+                    new SendLiteralChunk { Text = "</p>" }
+                });
+
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p>wastrue</p>", contents);
         }
 
@@ -186,15 +197,19 @@ namespace Spark.Compiler
 
             var trueChunks = new Chunk[] { new SendLiteralChunk { Text = "wastrue" } };
 
-            DoCompileView(compiler, new Chunk[]
-                                    {
-                                        new SendLiteralChunk {Text = "<p>"},
-                                        new LocalVariableChunk{Name="arg", Value="5"},
-                                        new ConditionalChunk{Type=ConditionalType.If, Condition="arg==6", Body=trueChunks},
-                                        new SendLiteralChunk {Text = "</p>"}
-                                    });
+            DoCompileView(
+                compiler,
+                new Chunk[]
+                {
+                    new SendLiteralChunk { Text = "<p>" },
+                    new LocalVariableChunk { Name = "arg", Value = "5" },
+                    new ConditionalChunk { Type = ConditionalType.If, Condition = "arg==6", Body = trueChunks },
+                    new SendLiteralChunk { Text = "</p>" }
+                });
+
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p></p>", contents);
         }
 
@@ -206,16 +221,20 @@ namespace Spark.Compiler
             var trueChunks = new Chunk[] { new SendLiteralChunk { Text = "wastrue" } };
             var falseChunks = new Chunk[] { new SendLiteralChunk { Text = "wasfalse" } };
 
-            DoCompileView(compiler, new Chunk[]
-                                    {
-                                        new SendLiteralChunk {Text = "<p>"},
-                                        new LocalVariableChunk{Name="arg", Value="5"},
-                                        new ConditionalChunk{Type=ConditionalType.If, Condition="arg==6", Body=trueChunks},
-                                        new ConditionalChunk{Type=ConditionalType.Else, Body=falseChunks},
-                                        new SendLiteralChunk {Text = "</p>"}
-                                    });
+            DoCompileView(
+                compiler,
+                new Chunk[]
+                {
+                    new SendLiteralChunk { Text = "<p>" },
+                    new LocalVariableChunk { Name = "arg", Value = "5" },
+                    new ConditionalChunk { Type = ConditionalType.If, Condition = "arg==6", Body = trueChunks },
+                    new ConditionalChunk { Type = ConditionalType.Else, Body = falseChunks },
+                    new SendLiteralChunk { Text = "</p>" }
+                });
+
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p>wasfalse</p>", contents);
         }
 
@@ -226,15 +245,19 @@ namespace Spark.Compiler
 
             var trueChunks = new Chunk[] { new SendLiteralChunk { Text = "wastrue" } };
 
-            DoCompileView(compiler, new Chunk[]
-                                    {
-                                        new SendLiteralChunk {Text = "<p>"},
-                                        new LocalVariableChunk{Name="arg", Value="5"},
-                                        new ConditionalChunk{Type=ConditionalType.Unless, Condition="arg==5", Body=trueChunks},
-                                        new SendLiteralChunk {Text = "</p>"}
-                                    });
+            DoCompileView(
+                compiler,
+                new Chunk[]
+                {
+                    new SendLiteralChunk { Text = "<p>" },
+                    new LocalVariableChunk { Name = "arg", Value = "5" },
+                    new ConditionalChunk { Type = ConditionalType.Unless, Condition = "arg==5", Body = trueChunks },
+                    new SendLiteralChunk { Text = "</p>" }
+                });
+
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p></p>", contents);
         }
 
@@ -245,15 +268,19 @@ namespace Spark.Compiler
 
             var trueChunks = new Chunk[] { new SendLiteralChunk { Text = "wastrue" } };
 
-            DoCompileView(compiler, new Chunk[]
-                                    {
-                                        new SendLiteralChunk {Text = "<p>"},
-                                        new LocalVariableChunk{Name="arg", Value="5"},
-                                        new ConditionalChunk{Type=ConditionalType.Unless, Condition="arg==6", Body=trueChunks},
-                                        new SendLiteralChunk {Text = "</p>"}
-                                    });
+            DoCompileView(
+                compiler,
+                new Chunk[]
+                {
+                    new SendLiteralChunk { Text = "<p>" },
+                    new LocalVariableChunk { Name = "arg", Value = "5" },
+                    new ConditionalChunk { Type = ConditionalType.Unless, Condition = "arg==6", Body = trueChunks },
+                    new SendLiteralChunk { Text = "</p>" }
+                });
+
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p>wastrue</p>", contents);
         }
 
@@ -265,12 +292,15 @@ namespace Spark.Compiler
                                BaseClass = "Spark.Tests.Stubs.StubSparkView",
                                NullBehaviour = NullBehaviour.Lenient
                            };
+            
             var chunks = new Chunk[]
-                         {
-                             new ViewDataChunk { Name="comment", Type="Spark.Tests.Models.Comment"},
-                             new SendExpressionChunk {Code = "comment.Text", SilentNulls = true}
-                         };
+            {
+                new ViewDataChunk { Name = "comment", Type = "Spark.Tests.Models.Comment" },
+                new SendExpressionChunk { Code = "comment.Text", SilentNulls = true }
+            };
+
             compiler.CompileView(new[] { chunks }, new[] { chunks });
+
             Assert.That(compiler.SourceCode.Contains("catch(System.NullReferenceException)"));
         }
 
@@ -283,11 +313,13 @@ namespace Spark.Compiler
                                NullBehaviour = NullBehaviour.Lenient
                            };
             var chunks = new Chunk[]
-                         {
-                             new ViewDataChunk { Name="comment", Type="Spark.Tests.Models.Comment"},
-                             new SendExpressionChunk {Code = "comment.Text", SilentNulls = false}
-                         };
+            {
+                new ViewDataChunk { Name = "comment", Type = "Spark.Tests.Models.Comment" },
+                new SendExpressionChunk { Code = "comment.Text", SilentNulls = false }
+            };
+
             compiler.CompileView(new[] { chunks }, new[] { chunks });
+
             Assert.That(compiler.SourceCode.Contains("catch(System.NullReferenceException)"));
         }
 
@@ -299,12 +331,15 @@ namespace Spark.Compiler
                                BaseClass = "Spark.Tests.Stubs.StubSparkView",
                                NullBehaviour = NullBehaviour.Strict
                            };
+            
             var chunks = new Chunk[]
-                         {
-                             new ViewDataChunk { Name="comment", Type="Spark.Tests.Models.Comment"},
-                             new SendExpressionChunk {Code = "comment.Text", SilentNulls = false}
-                         };
+            {
+                new ViewDataChunk { Name = "comment", Type = "Spark.Tests.Models.Comment" },
+                new SendExpressionChunk { Code = "comment.Text", SilentNulls = false }
+            };
+            
             compiler.CompileView(new[] { chunks }, new[] { chunks });
+            
             Assert.That(compiler.SourceCode.Contains("catch(System.NullReferenceException ex)"));
             Assert.That(compiler.SourceCode.Contains("ArgumentNullException("));
             Assert.That(compiler.SourceCode.Contains(", ex);"));
@@ -323,7 +358,9 @@ namespace Spark.Compiler
                                         new PageBaseTypeChunk {  BaseClass="Spark.Tests.Stubs.StubSparkView2"},
                                         new SendLiteralChunk{ Text = "Hello world"}
                                     });
+
             var instance = compiler.CreateInstance();
+            
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2)));
         }
 
@@ -336,13 +373,18 @@ namespace Spark.Compiler
                                BaseClass = "Spark.Tests.Stubs.StubSparkView",
                                NullBehaviour = NullBehaviour.Strict
                            };
-            DoCompileView(compiler, new Chunk[]
-                                    {
-                                        new PageBaseTypeChunk {BaseClass = "Spark.Tests.Stubs.StubSparkView2"},
-                                        new ViewDataModelChunk {TModel = "Spark.Tests.Models.Comment"},
-                                        new SendLiteralChunk {Text = "Hello world"}
-                                    });
+
+            DoCompileView(
+                compiler,
+                new Chunk[]
+                {
+                    new PageBaseTypeChunk { BaseClass = "Spark.Tests.Stubs.StubSparkView2" },
+                    new ViewDataModelChunk { TModel = "Spark.Tests.Models.Comment" },
+                    new SendLiteralChunk { Text = "Hello world" }
+                });
+            
             var instance = compiler.CreateInstance();
+            
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2)));
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2<Comment>)));
         }
@@ -360,7 +402,9 @@ namespace Spark.Compiler
                                         new PageBaseTypeChunk {BaseClass = "Spark.Tests.Stubs.StubSparkView3<Spark.Tests.Models.Comment, string>"},
                                         new SendLiteralChunk {Text = "Hello world"}
                                     });
+
             var instance = compiler.CreateInstance();
+
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2)));
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2<Comment>)));
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView3<Comment, string>)));
@@ -373,10 +417,12 @@ namespace Spark.Compiler
 
           var innerChunks = new Chunk[] { new SendLiteralChunk { Text = "*test*" } };
 
-          DoCompileView(compiler, new Chunk[]
-                                    {
-                                        new MarkdownChunk {Body = innerChunks}
-                                    });
+          DoCompileView(
+              compiler,
+              new Chunk[]
+              {
+                  new MarkdownChunk { Body = innerChunks }
+              });
 
           Assert.That(compiler.SourceCode, Does.Contain("using(MarkdownOutputScope())"));
           Assert.That(compiler.SourceCode, Does.Contain("Output.Write(\"*test*\");"));

--- a/src/Spark.Web.Tests/Compiler/SourceMappingTester.cs
+++ b/src/Spark.Web.Tests/Compiler/SourceMappingTester.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
+
 using NUnit.Framework;
 using Spark.FileSystem;
 using Spark.Tests.Stubs;

--- a/src/Spark.Web.Tests/Compiler/VisualBasicViewCompilerTester.cs
+++ b/src/Spark.Web.Tests/Compiler/VisualBasicViewCompilerTester.cs
@@ -99,6 +99,7 @@ namespace Spark.Compiler
             DoCompileView(compiler, new[] { new SendExpressionChunk { Code = "3 + 4" } });
             var instance = compiler.CreateInstance();
             string contents = instance.RenderView();
+
             Assert.AreEqual("7", contents);
         }
 
@@ -110,6 +111,7 @@ namespace Spark.Compiler
             DoCompileView(compiler, new[] { new SendExpressionChunk { Code = "CType(Nothing, String).Length" } });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.That(contents, Is.EqualTo("${CType(Nothing, String).Length}"));
         }
 
@@ -121,6 +123,7 @@ namespace Spark.Compiler
             DoCompileView(compiler, new[] { new SendExpressionChunk { Code = "CType(Nothing, String).Length", SilentNulls = true } });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.That(contents, Is.EqualTo(""));
         }
 
@@ -132,6 +135,7 @@ namespace Spark.Compiler
 
             DoCompileView(compiler, new[] { new SendExpressionChunk { Code = "CType(Nothing, String).Length" } });
             var instance = compiler.CreateInstance();
+
             Assert.That(() => instance.RenderView(), Throws.TypeOf<ArgumentNullException>());
         }
 
@@ -172,6 +176,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<ul><li>3</li><li>4</li><li>5</li></ul>", contents);
         }
 
@@ -201,6 +206,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<ul><li>3TrueFalse03</li><li>4FalseFalse13</li><li>5FalseTrue23</li></ul>", contents);
         }
 
@@ -219,6 +225,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("hello world:8", contents);
         }
 
@@ -234,9 +241,9 @@ namespace Spark.Compiler
             
             DoCompileView(compiler, new Chunk[] { new SendLiteralChunk { Text = "Hello" } });
             var instance = compiler.CreateInstance();
+
             Assert.AreEqual("Testing.Target.Namespace", instance.GetType().Namespace);
         }
-
 
         [Test]
         public void ProvideFullException()
@@ -266,6 +273,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p>wastrue</p>", contents);
         }
 
@@ -285,6 +293,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p></p>", contents);
         }
 
@@ -306,6 +315,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p>wasfalse</p>", contents);
         }
 
@@ -325,6 +335,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p></p>", contents);
         }
 
@@ -344,6 +355,7 @@ namespace Spark.Compiler
                                     });
             var instance = compiler.CreateInstance();
             var contents = instance.RenderView();
+
             Assert.AreEqual("<p>wastrue</p>", contents);
         }
 
@@ -361,6 +373,7 @@ namespace Spark.Compiler
                              new SendExpressionChunk {Code = "comment.Text", SilentNulls = false}
                          };
             compiler.CompileView(new[] { chunks }, new[] { chunks });
+
             Assert.That(compiler.SourceCode.Contains("Catch ex As Global.System.NullReferenceException"));
             Assert.That(compiler.SourceCode.Contains("ArgumentNullException("));
             Assert.That(compiler.SourceCode.Contains(", ex)"));
@@ -380,6 +393,7 @@ namespace Spark.Compiler
                                         new SendLiteralChunk{ Text = "Hello world"}
                                     });
             var instance = compiler.CreateInstance();
+
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2)));
         }
 
@@ -399,6 +413,7 @@ namespace Spark.Compiler
                                         new SendLiteralChunk {Text = "Hello world"}
                                     });
             var instance = compiler.CreateInstance();
+
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2)));
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2<Comment>)));
         }
@@ -417,6 +432,7 @@ namespace Spark.Compiler
                                         new SendLiteralChunk {Text = "Hello world"}
                                     });
             var instance = compiler.CreateInstance();
+
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2)));
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView2<Comment>)));
             Assert.That(instance, Is.InstanceOf(typeof(StubSparkView3<Comment, string>)));

--- a/src/Spark.Web.Tests/Configuration/SparkSectionHandlerTester.cs
+++ b/src/Spark.Web.Tests/Configuration/SparkSectionHandlerTester.cs
@@ -90,6 +90,7 @@ namespace Spark.Configuration
             descriptor.Templates.Add(Path.Combine("home", "index.spark"));
 
             var contents = engine.CreateInstance(descriptor).RenderView();
+
             Assert.AreEqual("<div>Alive</div>", contents);
         }
     }

--- a/src/Spark.Web.Tests/FileSystem/ViewFolderSettingsTester.cs
+++ b/src/Spark.Web.Tests/FileSystem/ViewFolderSettingsTester.cs
@@ -30,9 +30,12 @@ namespace Spark.FileSystem
             var engine = new SparkViewEngine(settings);
 
             var folder = engine.ViewFolder;
+
             Assert.IsAssignableFrom(typeof(CombinedViewFolder), folder);
+
             var combined = (CombinedViewFolder)folder;
             Assert.IsAssignableFrom(typeof(VirtualPathProviderViewFolder), combined.Second);
+            
             var vpp = (VirtualPathProviderViewFolder)combined.Second;
             Assert.AreEqual("~/MoreViews/", vpp.VirtualBaseDir);
         }

--- a/src/Spark.Web.Tests/ImportAndIncludeTester.cs
+++ b/src/Spark.Web.Tests/ImportAndIncludeTester.cs
@@ -40,13 +40,16 @@ namespace Spark
         [Test]
         public void ImportExplicitFile()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                 {
-                                     {Path.Combine("importing", "index.spark"), "<p><use import='extra.spark'/>hello ${name}</p>"},
-                                     {Path.Combine("importing", "extra.spark"), "this is imported <global name='\"world\"'/>"}
-                                 }, Path.Combine("importing", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    { Path.Combine("importing", "index.spark"), "<p><use import='extra.spark'/>hello ${name}</p>" },
+                    { Path.Combine("importing", "extra.spark"), "this is imported <global name='\"world\"'/>" }
+                },
+                Path.Combine("importing", "index.spark"));
 
             var contents = view.RenderView();
+
             Assert.AreEqual("<p>hello world</p>", contents);
             Assert.IsFalse(contents.Contains("import"));
         }
@@ -54,12 +57,16 @@ namespace Spark
         [Test]
         public void ImportExplicitFileFromShared()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                 {
-                                     {Path.Combine("importing", "index.spark"), "<p><use import='extra.spark'/>hello ${name}</p>"},
-                                     {Path.Combine("shared", "extra.spark"), "this is imported <global name='\"world\"'/>"}
-                                 }, Path.Combine("importing", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    { Path.Combine("importing", "index.spark"), "<p><use import='extra.spark'/>hello ${name}</p>" },
+                    { Path.Combine("shared", "extra.spark"), "this is imported <global name='\"world\"'/>" }
+                },
+                Path.Combine("importing", "index.spark"));
+            
             var contents = view.RenderView();
+            
             Assert.AreEqual("<p>hello world</p>", contents);
             Assert.IsFalse(contents.Contains("import"));
         }
@@ -67,14 +74,20 @@ namespace Spark
         [Test]
         public void ImportExplicitWithoutExtension()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                 {
-                                     {Path.Combine("importing", "index.spark"), "<p>${foo()} ${name}</p><use import='extra'/><use import='another'/>"},
-                                     {Path.Combine("importing", "another.spark"), "<macro name='foo'>hello</macro>"},
-                                     {Path.Combine("shared", "extra.spark"), "this is imported <global name='\"world\"'/>"}
-                                 }, Path.Combine("importing", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    {
+                        Path.Combine("importing", "index.spark"),
+                        "<p>${foo()} ${name}</p><use import='extra'/><use import='another'/>"
+                    },
+                    { Path.Combine("importing", "another.spark"), "<macro name='foo'>hello</macro>" },
+                    { Path.Combine("shared", "extra.spark"), "this is imported <global name='\"world\"'/>" }
+                },
+                Path.Combine("importing", "index.spark"));
 
             var contents = view.RenderView();
+
             Assert.AreEqual("<p>hello world</p>", contents);
             Assert.IsFalse(contents.Contains("import"));
         }
@@ -82,115 +95,158 @@ namespace Spark
         [Test]
         public void ImportImplicit()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("importing", "index.spark"), "<p>${foo()} ${name}</p>"},
-                                          {Path.Combine("importing", "_global.spark"), "<macro name='foo'>hello</macro>"},
-                                          {Path.Combine("shared", "_global.spark"), "this is imported <global name='\"world\"'/>"}
-                                      }, Path.Combine("importing", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    { Path.Combine("importing", "index.spark"), "<p>${foo()} ${name}</p>" },
+                    { Path.Combine("importing", "_global.spark"), "<macro name='foo'>hello</macro>" },
+                    { Path.Combine("shared", "_global.spark"), "this is imported <global name='\"world\"'/>" }
+                },
+                Path.Combine("importing", "index.spark"));
 
             var contents = view.RenderView();
+
             Assert.AreEqual("<p>hello world</p>", contents);
             Assert.IsFalse(contents.Contains("import"));
         }
 
-
         [Test]
         public void IncludeFile()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("including", "index.spark"), "<p><include href='stuff.spark'/></p>"},
-                                          {Path.Combine("including", "stuff.spark"), "hello world"}
-                                      }, Path.Combine("including", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    { Path.Combine("including", "index.spark"), "<p><include href='stuff.spark'/></p>" },
+                    { Path.Combine("including", "stuff.spark"), "hello world" }
+                },
+                Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+            
             Assert.AreEqual("<p>hello world</p>", contents);
         }
 
         [Test]
         public void MissingFileThrowsException()
         {
-            Assert.That(() =>
+            Assert.That(
+                () =>
+                {
+                    var view = CreateView(
+                        new InMemoryViewFolder
+                        {
                             {
-                                var view = CreateView(new InMemoryViewFolder
-                                                          {
-                                                              {
-                                                                  Path.Combine("including", "index.spark"),
-                                                                  "<p><include href='stuff.spark'/></p>"
-                                                                  }
-                                                          }, Path.Combine("including", "index.spark"));
-                                view.RenderView();
-                            },
-                        Throws.TypeOf<CompilerException>());
+                                Path.Combine("including", "index.spark"),
+                                "<p><include href='stuff.spark'/></p>"
+                            }
+                        },
+                        Path.Combine("including", "index.spark"));
+                    view.RenderView();
+                },
+                Throws.TypeOf<CompilerException>());
         }
 
 
         [Test]
         public void MissingFileWithEmptyFallbackIsBlank()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("including", "index.spark"), "<p><include href='stuff.spark'><fallback/></include></p>"}
-                                      }, Path.Combine("including", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    {
+                        Path.Combine("including", "index.spark"),
+                        "<p><include href='stuff.spark'><fallback/></include></p>"
+                    }
+                },
+                Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+
             Assert.AreEqual("<p></p>", contents);
         }
 
         [Test]
         public void MissingFileWithFallbackUsesContents()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("including", "index.spark"), "<p><include href='stuff.spark'><fallback>hello world</fallback></include></p>"}
-                                      }, Path.Combine("including", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    {
+                        Path.Combine("including", "index.spark"),
+                        "<p><include href='stuff.spark'><fallback>hello world</fallback></include></p>"
+                    }
+                },
+                Path.Combine("including", "index.spark"));
+
             var contents = view.RenderView();
+
             Assert.AreEqual("<p>hello world</p>", contents);
         }
 
         [Test]
         public void ValidIncludeFallbackDisappears()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("including", "index.spark"), "<p><include href='stuff.spark'><fallback>hello world</fallback></include></p>"},
-                                          {Path.Combine("including", "stuff.spark"), "another file"}
-                                      }, Path.Combine("including", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    {
+                        Path.Combine("including", "index.spark"),
+                        "<p><include href='stuff.spark'><fallback>hello world</fallback></include></p>"
+                    },
+                    { Path.Combine("including", "stuff.spark"), "another file" }
+                },
+                Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+            
             Assert.AreEqual("<p>another file</p>", contents);
         }
 
         [Test]
         public void FallbackContainsAnotherInclude()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("including", "index.spark"), "<p><include href='stuff.spark'><fallback><include href='other.spark'/></fallback></include></p>"},
-                                          {Path.Combine("including", "other.spark"), "other file"}
-                                      }, Path.Combine("including", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    {
+                        Path.Combine("including", "index.spark"),
+                        "<p><include href='stuff.spark'><fallback><include href='other.spark'/></fallback></include></p>"
+                    },
+                    { Path.Combine("including", "other.spark"), "other file" }
+                },
+                Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+            
             Assert.AreEqual("<p>other file</p>", contents);
         }
 
         [Test]
         public void IncludeRelativePath()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("including", "index.spark"), "<p><include href='../lib/other.spark'/></p>"},
-                                          {Path.Combine("lib", "other.spark"), "other file"}
-                                      }, Path.Combine("including", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    { Path.Combine("including", "index.spark"), "<p><include href='../lib/other.spark'/></p>" },
+                    { Path.Combine("lib", "other.spark"), "other file" }
+                },
+                Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+
             Assert.AreEqual("<p>other file</p>", contents);
         }
         [Test]
         public void IncludeInsideAnInclude()
         {
-            var view = CreateView(new InMemoryViewFolder
-                                      {
-                                          {Path.Combine("including", "index.spark"), "<p><include href='../lib/other.spark'/></p>"},
-                                          {Path.Combine("lib", "other.spark"), "other <include href='third.spark'/> file"},
-                                          {Path.Combine("lib", "third.spark"), "third file"}
-                                      }, Path.Combine("including", "index.spark"));
+            var view = CreateView(
+                new InMemoryViewFolder
+                {
+                    { Path.Combine("including", "index.spark"), "<p><include href='../lib/other.spark'/></p>" },
+                    { Path.Combine("lib", "other.spark"), "other <include href='third.spark'/> file" },
+                    { Path.Combine("lib", "third.spark"), "third file" }
+                },
+                Path.Combine("including", "index.spark"));
             var contents = view.RenderView();
             Assert.AreEqual("<p>other third file file</p>", contents);
         }
@@ -203,7 +259,9 @@ namespace Spark
                                           {Path.Combine("including", "index.spark"), "<p xmlns:x='http://www.w3.org/2001/XInclude'><include/><x:include href='../lib/other.spark'/></p>"},
                                           {Path.Combine("lib", "other.spark"), "other file"}
                                       }, Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+            
             Assert.AreEqual("<p xmlns:x='http://www.w3.org/2001/XInclude\'><include></include>other file</p>", contents);
         }
 
@@ -215,7 +273,9 @@ namespace Spark
                                           {Path.Combine("including", "index.spark"), "<p><include href='item.spark' parse='text'/></p>"},
                                           {Path.Combine("including", "item.spark"), "<li>at&t</li>"}
                                       }, Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+            
             Assert.AreEqual("<p>&lt;li&gt;at&amp;t&lt;/li&gt;</p>", contents);
         }
 
@@ -227,7 +287,9 @@ namespace Spark
                                           {Path.Combine("including", "index.spark"), "<p><include href='jquery.templ.htm' parse='html'/></p>"},
                                           {Path.Combine("including", "jquery.templ.htm"), "<h4>${Title}</h4>"}
                                       }, Path.Combine("including", "index.spark"));
+            
             var contents = view.RenderView();
+            
             Assert.AreEqual("<p><h4>${Title}</h4></p>", contents);
         }
     }

--- a/src/Spark.Web.Tests/Parser/AutomaticEncodingTester.cs
+++ b/src/Spark.Web.Tests/Parser/AutomaticEncodingTester.cs
@@ -43,7 +43,7 @@ namespace Spark.Parser
                 .SetPageBaseType(typeof(StubSparkView))
                 .SetAutomaticEncoding(automaticEncoding);
             var container = new SparkServiceContainer(this._settings);
-
+            
             this._viewFolder = new InMemoryViewFolder();
 
             container.SetServiceBuilder<IViewFolder>(c => this._viewFolder);
@@ -89,7 +89,6 @@ namespace Spark.Parser
             Assert.IsFalse(((ExpressionNode)result.Value[0]).AutomaticEncoding);
         }
 
-
         [Test]
         public void DollarHasEncodedContentWhenEnabled()
         {
@@ -101,7 +100,6 @@ namespace Spark.Parser
             Assert.AreEqual("\"hello world\"", (string)((ExpressionNode)result.Value[0]).Code);
             Assert.IsTrue(((ExpressionNode)result.Value[0]).AutomaticEncoding);
         }
-
 
         [Test]
         public void BangSyntaxStillHasRawContentWhenEnabled()
@@ -142,7 +140,6 @@ namespace Spark.Parser
             Assert.AreEqual("&lt;span&gt;hello&lt;/span&gt; &lt;span&gt;world&lt;/span&gt;", content);
         }
 
-
         [Test]
         public void HashSyntaxForStatementsByDefault()
         {
@@ -167,7 +164,6 @@ namespace Spark.Parser
             Assert.That(statement.Code.ToString(), Is.EqualTo("bernate  "));
         }
 
-
         [Test]
         public void HashSyntaxIgnoredWhenCustomMarkerProvided()
         {
@@ -179,6 +175,5 @@ namespace Spark.Parser
             var statement = result.Value.OfType<StatementNode>().Any();
             Assert.That(statement, Is.False);
         }
-
     }
 }

--- a/src/Spark.Web.Tests/Parser/CSharpSyntaxProviderTester.cs
+++ b/src/Spark.Web.Tests/Parser/CSharpSyntaxProviderTester.cs
@@ -33,6 +33,7 @@ namespace Spark.Parser
         {
             var context = new VisitorContext { ViewFolder = new FileSystemViewFolder("Spark.Tests.Views") };
             var result = this._syntax.GetChunks(context, Path.Combine("Home", "childview.spark"));
+
             Assert.IsNotNull(result);
         }
 
@@ -57,7 +58,6 @@ namespace Spark.Parser
 
             Assert.IsNotNull(code);
         }
-
 
         [Test]
         public void StatementAndExpressionInCode()

--- a/src/Spark.Web.Tests/PartialProviderTester.cs
+++ b/src/Spark.Web.Tests/PartialProviderTester.cs
@@ -15,6 +15,7 @@ namespace Spark
         public void Init()
         {
             this._viewPath = "fake/path";
+
             this._partialProvider = MockRepository.GenerateMock<IPartialProvider>();
             this._engine = new SparkViewEngine(new SparkSettings())
             {

--- a/src/Spark.Web.Tests/PrefixSupportTester.cs
+++ b/src/Spark.Web.Tests/PrefixSupportTester.cs
@@ -67,13 +67,19 @@ namespace Spark
             var output = new StringWriter();
             view.RenderView(output);
 
-            ContainsInOrder(output.ToString(),
-                            "<li", "alpha", "</li>",
-                            "<li", "beta", "</li>",
-                            "<li", "gamma", "</li>",
-                            "<var x=\"1/0\">element ignored</var>",
-                            "<p each=\"5\">attribute ignored</p>"
-                );
+            ContainsInOrder(
+                output.ToString(),
+                "<li",
+                "alpha",
+                "</li>",
+                "<li",
+                "beta",
+                "</li>",
+                "<li",
+                "gamma",
+                "</li>",
+                "<var x=\"1/0\">element ignored</var>",
+                "<p each=\"5\">attribute ignored</p>");
         }
 
 
@@ -86,12 +92,19 @@ namespace Spark
             var output = new StringWriter();
             view.RenderView(output);
 
-            ContainsInOrder(output.ToString(),
-                            "<li", "alpha", "</li>",
-                            "<li", "beta", "</li>",
-                            "<li", "gamma", "</li>",
-                            "<var x=\"1/0\">element ignored</var>",
-                            "<p each=\"5\">attribute ignored</p>");
+            ContainsInOrder(
+                output.ToString(),
+                "<li",
+                "alpha",
+                "</li>",
+                "<li",
+                "beta",
+                "</li>",
+                "<li",
+                "gamma",
+                "</li>",
+                "<var x=\"1/0\">element ignored</var>",
+                "<p each=\"5\">attribute ignored</p>");
         }
 
 
@@ -102,11 +115,12 @@ namespace Spark
             var output = new StringWriter();
             view.RenderView(output);
 
-            ContainsInOrder(output.ToString(),
-                            "ok1",
-                            "ok2",
-                            "ok3",
-                            "ok4");
+            ContainsInOrder(
+                output.ToString(),
+                "ok1",
+                "ok2",
+                "ok3",
+                "ok4");
 
             Assert.IsFalse(output.ToString().Contains("fail"));
             Assert.IsFalse(output.ToString().Contains("if"));
@@ -124,18 +138,18 @@ namespace Spark
             var output = new StringWriter();
             view.RenderView(output);
 
-            ContainsInOrder(output.ToString(),
-                            "<p>one</p>",
-                            "<p>two</p>",
-                            "<p>Hello, world!</p>",
-                            "<p>three</p>",
-                            "<p>four</p>",
-                            "<macro:ignored>ignored</macro:ignored>",
-                            "<content:ignored>ignored</content:ignored>",
-                            "<use:ignored>ignored</use:ignored>",
-                            "<render:ignored>ignored</render:ignored>",
-                            "<segment:ignored>ignored</segment:ignored>"
-                );
+            ContainsInOrder(
+                output.ToString(),
+                "<p>one</p>",
+                "<p>two</p>",
+                "<p>Hello, world!</p>",
+                "<p>three</p>",
+                "<p>four</p>",
+                "<macro:ignored>ignored</macro:ignored>",
+                "<content:ignored>ignored</content:ignored>",
+                "<use:ignored>ignored</use:ignored>",
+                "<render:ignored>ignored</render:ignored>",
+                "<segment:ignored>ignored</segment:ignored>");
         }
 
         [Test]
@@ -147,16 +161,16 @@ namespace Spark
             var output = new StringWriter();
             view.RenderView(output);
 
-            ContainsInOrder(output.ToString(),
-                            "<p>one</p>",
-                            "<p>two</p>",
-                            "<p>three</p>",
-                            "<macro:ignored>ignored</macro:ignored>",
-                            "<content:ignored>ignored</content:ignored>",
-                            "<use:ignored>ignored</use:ignored>",
-                            "<render:ignored>ignored</render:ignored>",
-                            "<segment:ignored>ignored</segment:ignored>"
-                );
+            ContainsInOrder(
+                output.ToString(),
+                "<p>one</p>",
+                "<p>two</p>",
+                "<p>three</p>",
+                "<macro:ignored>ignored</macro:ignored>",
+                "<content:ignored>ignored</content:ignored>",
+                "<use:ignored>ignored</use:ignored>",
+                "<render:ignored>ignored</render:ignored>",
+                "<segment:ignored>ignored</segment:ignored>");
         }
 
         [Test]
@@ -177,16 +191,16 @@ namespace Spark
             var output = new StringWriter();
             view.RenderView(output);
 
-            ContainsInOrder(output.ToString(),
-                            "<p>one</p>",
-                            "<p>two</p>",
-                            "<p>three</p>",
-                            "<macro:ignored>ignored</macro:ignored>",
-                            "<content:ignored>ignored</content:ignored>",
-                            "<use:ignored>ignored</use:ignored>",
-                            "<render:ignored>ignored</render:ignored>",
-                            "<section:ignored>ignored</section:ignored>"
-                );
+            ContainsInOrder(
+                output.ToString(),
+                "<p>one</p>",
+                "<p>two</p>",
+                "<p>three</p>",
+                "<macro:ignored>ignored</macro:ignored>",
+                "<content:ignored>ignored</content:ignored>",
+                "<use:ignored>ignored</use:ignored>",
+                "<render:ignored>ignored</render:ignored>",
+                "<section:ignored>ignored</section:ignored>");
         }
 
         [Test]
@@ -202,14 +216,14 @@ namespace Spark
             var output = new StringWriter();
             view.RenderView(output);
 
-            ContainsInOrder(output.ToString(),
-                            "<p>one</p>",
-                            "<p>two</p>",
-                            "<p>Hello, world!</p>",
-                            "<p>three</p>",
-                            "<p>four</p>",
-                            "<var x=\"1/0\">ignored</var>"
-                );
+            ContainsInOrder(
+                output.ToString(),
+                "<p>one</p>",
+                "<p>two</p>",
+                "<p>Hello, world!</p>",
+                "<p>three</p>",
+                "<p>four</p>",
+                "<var x=\"1/0\">ignored</var>");
         }
     }
 }

--- a/src/Spark.Web.Tests/SparkExtensionTester.cs
+++ b/src/Spark.Web.Tests/SparkExtensionTester.cs
@@ -52,7 +52,9 @@ namespace Spark
         public ISparkExtension CreateExtension(VisitorContext context, ElementNode node)
         {
             if (node.Name == "unittest")
+            {
                 return new TestExtension();
+            }
 
             return null;
         }
@@ -61,14 +63,15 @@ namespace Spark
     internal class TestExtension : ISparkExtension
     {
         public void VisitNode(INodeVisitor visitor, IList<Node> body, IList<Chunk> chunks)
-        {
-            
+        {   
         }
 
         public void VisitChunk(IChunkVisitor visitor, OutputLocation location, IList<Chunk> chunks, StringBuilder output)
         {
             if (location == OutputLocation.UsingNamespace)
+            {
                 output.AppendLine("//this was a test");
+            }
         }
     }
 }

--- a/src/Spark.Web.Tests/SparkViewFactoryTester.cs
+++ b/src/Spark.Web.Tests/SparkViewFactoryTester.cs
@@ -52,7 +52,6 @@ namespace Spark.Tests
             sb = new StringBuilder();
            
             mocks = new MockRepository();
-
         }
 
         StubViewContext MakeViewContext(string viewName, string masterName)
@@ -65,8 +64,6 @@ namespace Spark.Tests
             return new StubViewContext { ControllerName = "Home", ViewName = viewName, MasterName = masterName, Output = sb, Data = data };
         }
 
-
-
         [Test]
         public void RenderPlainView()
         {
@@ -76,7 +73,6 @@ namespace Spark.Tests
 
             mocks.VerifyAll();
         }
-
 
         [Test]
         public void ForEachTest()
@@ -88,16 +84,15 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
+
             Assert.That(content.Contains(@"<li class=""odd"">1: foo</li>"));
             Assert.That(content.Contains(@"<li class=""even"">2: bar</li>"));
             Assert.That(content.Contains(@"<li class=""odd"">3: baaz</li>"));
         }
 
-
         [Test]
         public void GlobalSetTest()
         {
-
             mocks.ReplayAll();
 
             factory.RenderView(MakeViewContext("globalset", null));
@@ -105,6 +100,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
+
             Assert.That(content.Contains("<p>default: Global set test</p>"));
             Assert.That(content.Contains("<p>7==7</p>"));
         }
@@ -118,6 +114,7 @@ namespace Spark.Tests
 
             mocks.VerifyAll();
             string content = sb.ToString();
+
             Assert.That(content.Contains("<title>Standalone Index View</title>"));
             Assert.That(content.Contains("<h1>Standalone Index View</h1>"));
             Assert.That(content.Contains("<p>no header by default</p>"));
@@ -127,13 +124,13 @@ namespace Spark.Tests
         [Test]
         public void CaptureNamedContent()
         {
-
             mocks.ReplayAll();
 
             factory.RenderView(MakeViewContext("namedcontent", "layout"));
 
             mocks.VerifyAll();
             string content = sb.ToString();
+
             Assert.That(content.Contains("<p>main content</p>"));
             Assert.That(content.Contains("<p>this is the header</p>"));
             Assert.That(content.Contains("<p>footer part one</p>"));
@@ -149,6 +146,7 @@ namespace Spark.Tests
 
             mocks.VerifyAll();
             string content = sb.ToString();
+
             Assert.That(content.Contains("<li>Partial where x=\"zero\"</li>"));
             Assert.That(content.Contains("<li>Partial where x=\"one\"</li>"));
             Assert.That(content.Contains("<li>Partial where x=\"two\"</li>"));
@@ -165,6 +163,7 @@ namespace Spark.Tests
 
             mocks.VerifyAll();
             string content = sb.ToString();
+
             Assert.That(content.Contains("<li>Partial where x=\"zero\"</li>"));
             Assert.That(content.Contains("<li>Partial where x=\"one\"</li>"));
             Assert.That(content.Contains("<li>Partial where x=\"two\"</li>"));
@@ -181,6 +180,7 @@ namespace Spark.Tests
 
             mocks.VerifyAll();
             string content = sb.ToString();
+
             Assert.That(content.Contains("<li class=\"odd\">one</li>"));
             Assert.That(content.Contains("<li class=\"even\">two</li>"));
         }
@@ -209,6 +209,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
+
             Assert.That(!content.Contains("<if"));
             Assert.That(!content.Contains("<else"));
 
@@ -220,7 +221,6 @@ namespace Spark.Tests
             Assert.That(content.Contains("<p>argisstillnot6</p>"));
         }
 
-
         [Test]
         public void IfElseAttributes()
         {
@@ -230,6 +230,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
+
             Assert.That(!content.Contains("<if"));
             Assert.That(!content.Contains("<else"));
 
@@ -250,6 +251,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
+
             Assert.That(!content.Contains("<unless"));
 
             Assert.That(content.Contains("<p>argisnot6</p>"));
@@ -265,6 +267,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
+
             Assert.That(!content.Contains("<unless"));
 
             Assert.That(content.Contains("<p>argisnot6</p>"));
@@ -279,6 +282,7 @@ namespace Spark.Tests
             factory.RenderView(viewContext);
             mocks.VerifyAll();
             string content = sb.ToString();
+
             Assert.That(content, Tests.Contains.InOrder(
                 "<p>Hi Bob!</p>",
                 "<p>Administrator James</p>",
@@ -301,6 +305,7 @@ namespace Spark.Tests
                 "<p>Test user.</p>",
                 "<p>Anonymous user.</p>"));
         }
+
         [Test]
         public void ChainingElseIfAttribute()
         {
@@ -417,11 +422,17 @@ namespace Spark.Tests
             factory.RenderView(viewContext);
             mocks.VerifyAll();
             string content = sb.ToString();
-            Assert.That(content, Contains.InOrder(
-                "<p>Bob</p>", "<p>Alpha</p>",
-                "<p>Bob</p>", "<p>Beta</p>",
-                "<p>Bob</p>", "<p>Gamma</p>",
-                "<span class=\"yadda\">Rating: 5</span>"));
+
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<p>Bob</p>",
+                    "<p>Alpha</p>",
+                    "<p>Bob</p>",
+                    "<p>Beta</p>",
+                    "<p>Bob</p>",
+                    "<p>Gamma</p>",
+                    "<span class=\"yadda\">Rating: 5</span>"));
         }
 
         [Test]
@@ -433,16 +444,22 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
-            Assert.That(content, Contains.InOrder(
-                "<p>0: Alpha</p>",
-                "<p>1: Beta</p>",
-                "<p>2: Gamma</p>",
-                "<p>3: Delta</p>",
-                "<li ", "class='even'>Alpha</li>",
-                "<li ", "class='odd'>Beta</li>",
-                "<li ", "class='even'>Gamma</li>",
-                "<li ", "class='odd'>Delta</li>"
-                ));
+
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<p>0: Alpha</p>",
+                    "<p>1: Beta</p>",
+                    "<p>2: Gamma</p>",
+                    "<p>3: Delta</p>",
+                    "<li ",
+                    "class='even'>Alpha</li>",
+                    "<li ",
+                    "class='odd'>Beta</li>",
+                    "<li ",
+                    "class='even'>Gamma</li>",
+                    "<li ",
+                    "class='odd'>Delta</li>"));
         }
 
         [Test]
@@ -454,13 +471,13 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString().Replace(" ", "").Replace("\t", "").Replace("\r\n", "");
+
             Assert.That(content, Contains.InOrder(
                 "<tr><td>one</td><td>0</td><td>4</td><td>True</td><td>False</td><td>False</td><td>True</td></tr>",
                 "<tr><td>two</td><td>1</td><td>4</td><td>False</td><td>False</td><td>True</td><td>False</td></tr>",
                 "<tr><td>three</td><td>2</td><td>4</td><td>False</td><td>False</td><td>False</td><td>True</td></tr>",
                 "<tr><td>four</td><td>3</td><td>4</td><td>False</td><td>True</td><td>True</td><td>False</td></tr>"));
         }
-
 
         [Test]
         public void ConditionalTestElement()
@@ -480,7 +497,6 @@ namespace Spark.Tests
                             "<p>out-6</p>"));
 
             Assert.IsFalse(content.Contains("fail"));
-
         }
 
         [Test]
@@ -492,8 +508,8 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString().Replace(" ", "").Replace("\r", "").Replace("\n", "");
-            Assert.AreEqual("<p>a</p><p>b</p><p>c</p><p>d</p><p>e</p><p>f</p>", content);
 
+            Assert.AreEqual("<p>a</p><p>b</p><p>c</p><p>d</p><p>e</p><p>f</p>", content);
         }
 
         [Test]
@@ -505,6 +521,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString();
+
             Assert.That(content, Contains.InOrder(
                 "Hi there, alpha.",
                 "Hi there, alpha."));
@@ -519,8 +536,8 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString().Replace(" ", "").Replace("\r", "").Replace("\n", "");
-            Assert.AreEqual("<p>a:1</p><p>b:2</p><p>c:3%></p><p>d:<%4%></p><p>e:5%></p><p>f:<%6%></p>", content);
 
+            Assert.AreEqual("<p>a:1</p><p>b:2</p><p>c:3%></p><p>d:<%4%></p><p>e:5%></p><p>f:<%6%></p>", content);
         }
 
         [Test]
@@ -532,6 +549,7 @@ namespace Spark.Tests
             mocks.VerifyAll();
 
             string content = sb.ToString().Replace(" ", "").Replace("\r", "").Replace("\n", "");
+
             Assert.AreEqual("<p>a\\\"b</p><p>c\\\"}d</p>", content);
         }
 
@@ -545,10 +563,12 @@ namespace Spark.Tests
 
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                "<img src=\"/TestApp/content/images/etc.png\"/>",
-                "<script src=\"/TestApp/content/js/etc.js\"></script>",
-                "<p class=\"~/blah.css\"></p>"));
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<img src=\"/TestApp/content/images/etc.png\"/>",
+                    "<script src=\"/TestApp/content/js/etc.js\"></script>",
+                    "<p class=\"~/blah.css\"></p>"));
         }
 
         [Test]
@@ -561,8 +581,7 @@ namespace Spark.Tests
 
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                "<p>SortByCategory</p>"));
+            Assert.That(content, Contains.InOrder("<p>SortByCategory</p>"));
         }
 
         [Test]
@@ -580,7 +599,6 @@ namespace Spark.Tests
                 "<div>Hello world</div>",
                 "<div>\r\n  Again: Hello world\r\n</div>"));
         }
-
 
         [Test]
         public void AddViewDataDifferentTypes()
@@ -601,20 +619,22 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                "xbox",
-                "xtop",
-                "xb1",
-                "xb2",
-                "xb3",
-                "xb4",
-                "xboxcontent",
-                "Hello World",
-                "xbottom",
-                "xb4",
-                "xb3",
-                "xb2",
-                "xb1"));
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "xbox",
+                    "xtop",
+                    "xb1",
+                    "xb2",
+                    "xb3",
+                    "xb4",
+                    "xboxcontent",
+                    "Hello World",
+                    "xbottom",
+                    "xb4",
+                    "xb3",
+                    "xb2",
+                    "xb1"));
         }
 
         [Test]
@@ -626,22 +646,24 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                "xbox",
-                "xtop",
-                "xb1",
-                "xb2",
-                "xb3",
-                "xb4",
-                "xboxcontent",
-                "title=\"My Tooltip\"",
-                "<h3>This is a test</h3>",
-                "Hello World",
-                "xbottom",
-                "xb4",
-                "xb3",
-                "xb2",
-                "xb1"));
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "xbox",
+                    "xtop",
+                    "xb1",
+                    "xb2",
+                    "xb3",
+                    "xb4",
+                    "xboxcontent",
+                    "title=\"My Tooltip\"",
+                    "<h3>This is a test</h3>",
+                    "Hello World",
+                    "xbottom",
+                    "xb4",
+                    "xb3",
+                    "xb2",
+                    "xb1"));
         }
 
         [Test]
@@ -653,26 +675,28 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                "xbox",
-                "xtop",
-                "xb1",
-                "xb2",
-                "xb3",
-                "xb4",
-                "xboxcontent",
-                "<section name=\"top\">",
-                "<h3>This is a test</h3>",
-                "</section>",
-                "<section name=\"tooltip\">",
-                "My Tooltip",
-                "</section>",
-                "<p>Hello World</p>",
-                "xbottom",
-                "xb4",
-                "xb3",
-                "xb2",
-                "xb1"));
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "xbox",
+                    "xtop",
+                    "xb1",
+                    "xb2",
+                    "xb3",
+                    "xb4",
+                    "xboxcontent",
+                    "<section name=\"top\">",
+                    "<h3>This is a test</h3>",
+                    "</section>",
+                    "<section name=\"tooltip\">",
+                    "My Tooltip",
+                    "</section>",
+                    "<p>Hello World</p>",
+                    "xbottom",
+                    "xb4",
+                    "xb3",
+                    "xb2",
+                    "xb1"));
         }
 
         [Test]
@@ -686,26 +710,28 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                "xbox",
-                "xtop",
-                "xb1",
-                "xb2",
-                "xb3",
-                "xb4",
-                "xboxcontent",
-                "title=\"My Tooltip\"",
-                "<h3>This is a test</h3>",
-                "Hello World",
-                "xbottom",
-                "xb4",
-                "xb3",
-                "xb2",
-                "xb1"));
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "xbox",
+                    "xtop",
+                    "xb1",
+                    "xb2",
+                    "xb3",
+                    "xb4",
+                    "xboxcontent",
+                    "title=\"My Tooltip\"",
+                    "<h3>This is a test</h3>",
+                    "Hello World",
+                    "xbottom",
+                    "xb4",
+                    "xb3",
+                    "xb2",
+                    "xb1"));
         }
 
         [Test]
-        public void RenderlPartialWithDotInName()
+        public void RenderPartialWithDotInName()
         {
             mocks.ReplayAll();
             var viewContext = MakeViewContext("render-dotted-partial", null);
@@ -713,12 +739,13 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
+            Assert.That(
+                content,
+                Contains.InOrder(
                     "<p>",
                     "this.is.some.text:",
                     "test456",
-                    "</p>"
-                    ));
+                    "</p>"));
 
             Assert.IsFalse(content.Contains("<PartialWith.Dot"));
         }
@@ -783,25 +810,26 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                        "<div>",
-                        @"<elt1 a1=""1"" a3=""3""></elt1>",
-                        @"<elt2 a1=""1"" a3=""3""></elt2>",
-                        @"<elt3 a1=""1"" a2="""" a3=""3""></elt3>",
-                        @"<elt4 a1=""1"" a2=""2"" a3=""3""></elt4>",
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<div>",
+                    @"<elt1 a1=""1"" a3=""3""></elt1>",
+                    @"<elt2 a1=""1"" a3=""3""></elt2>",
+                    @"<elt3 a1=""1"" a2="""" a3=""3""></elt3>",
+                    @"<elt4 a1=""1"" a2=""2"" a3=""3""></elt4>",
 
-                        @"<elt5 a1=""1"" a2="" beta"" a3=""3""></elt5>",
-                        @"<elt6 a1=""1"" a2=""alpha beta"" a3=""3""></elt6>",
-                        @"<elt7 a1=""1"" a2=""alpha"" a3=""3""></elt7>",
-                        @"<elt8 a1=""1"" a3=""3""></elt8>",
+                    @"<elt5 a1=""1"" a2="" beta"" a3=""3""></elt5>",
+                    @"<elt6 a1=""1"" a2=""alpha beta"" a3=""3""></elt6>",
+                    @"<elt7 a1=""1"" a2=""alpha"" a3=""3""></elt7>",
+                    @"<elt8 a1=""1"" a3=""3""></elt8>",
 
-                        @"<elt9 a1=""1"" a2="" beta"" a3=""3""></elt9>",
-                        @"<elt10 a1=""1"" a2=""alpha beta"" a3=""3""></elt10>",
+                    @"<elt9 a1=""1"" a2="" beta"" a3=""3""></elt9>",
+                    @"<elt10 a1=""1"" a2=""alpha beta"" a3=""3""></elt10>",
 
-                        @"<elt11 a1=""1"" a3=""3""></elt11>",
-                        @"<elt12 a1=""1"" a2=""onetwo"" a3=""3""></elt12>",
-                        "</div>"
-            ));
+                    @"<elt11 a1=""1"" a3=""3""></elt11>",
+                    @"<elt12 a1=""1"" a2=""onetwo"" a3=""3""></elt12>",
+                    "</div>"));
         }
 
         [Test]
@@ -813,10 +841,11 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>",
-                            "<?php yadda yadda yadda ?>"
-                ));
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<?xml version=\"1.0\" encoding=\"utf-8\" ?>",
+                    "<?php yadda yadda yadda ?>"));
         }
 
 
@@ -829,10 +858,16 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                            "<li", "class=", "selected", "blah", "</li>",
-                            "blah", "blah"));
-
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<li",
+                    "class=",
+                    "selected",
+                    "blah",
+                    "</li>",
+                    "blah",
+                    "blah"));
         }
 
         [Test]
@@ -847,12 +882,21 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                            "<p>", "alpha", "</p>",
-                            "<p>", "beta", "</p>",
-                            "<p>", "gamma", "</p>",
-                            "<p>", "delta", "</p>"
-                            ));
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<p>",
+                    "alpha",
+                    "</p>",
+                    "<p>",
+                    "beta",
+                    "</p>",
+                    "<p>",
+                    "gamma",
+                    "</p>",
+                    "<p>",
+                    "delta",
+                    "</p>"));
         }
 
         [Test]
@@ -986,7 +1030,6 @@ namespace Spark.Tests
                 "<h7 class=\"one&two<three\"></h7>"));
         }
 
-
         [Test]
         public void OnceAttribute()
         {
@@ -1008,7 +1051,6 @@ namespace Spark.Tests
             Assert.IsFalse(content.Contains("bar3"));
             Assert.IsFalse(content.Contains("a2"));
         }
-
 
         [Test]
         public void EachAttributeWorksOnSpecialNodes()
@@ -1103,12 +1145,13 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                            "<p><strong>hi</strong></p>",
-                            "<p>&lt;strong&gt;hi&lt;/strong&gt;</p>",
-                            "yadda",
-                            "<p>42</p>"));
-
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<p><strong>hi</strong></p>",
+                    "<p>&lt;strong&gt;hi&lt;/strong&gt;</p>",
+                    "yadda",
+                    "<p>42</p>"));
         }
 
         [Test]
@@ -1120,12 +1163,13 @@ namespace Spark.Tests
             mocks.VerifyAll();
             string content = sb.ToString();
 
-            Assert.That(content, Contains.InOrder(
-                            "<p>3hello</p>",
-                            "<p>2hello.</p>",
-                            "<p>1hello..</p>",
-                            "<p>0hello...</p>"));
-
+            Assert.That(
+                content,
+                Contains.InOrder(
+                    "<p>3hello</p>",
+                    "<p>2hello.</p>",
+                    "<p>1hello..</p>",
+                    "<p>0hello...</p>"));
         }
 
         [Test]
@@ -1148,14 +1192,16 @@ namespace Spark.Tests
             string content = sb.ToString();
 
             var stripped = content.Replace(" ", "").Replace("\t", "").Replace("\r\n", "");
-            Assert.That(stripped, Is.EqualTo(
-                "[001][101]" +
-                "[201][102]" +
-                "[201][104][202]" +
-                "[106][002][107]" +
-                "[201][109][202]" +
-                "[111][202]" +
-                "[112][003]"));
+            Assert.That(
+                stripped,
+                Is.EqualTo(
+                    "[001][101]" +
+                    "[201][102]" +
+                    "[201][104][202]" +
+                    "[106][002][107]" +
+                    "[201][109][202]" +
+                    "[111][202]" +
+                    "[112][003]"));
         }
 
         [Test]
@@ -1273,7 +1319,6 @@ namespace Spark.Tests
             Assert.That(content, Is.EqualTo(@"<img attr=""something; other='value1, value2'""/>"));
         }
 
-
         [Test]
         public void ShadeFileRenders()
         {
@@ -1362,7 +1407,6 @@ namespace Spark.Tests
                 "</ul>"));
         }
 
-
         [Test]
         public void ShadeTextMayContainExpressions()
         {
@@ -1430,7 +1474,6 @@ namespace Spark.Tests
                 "<p>Int32:42</p>"));
         }
 
-
         [Test]
         public void TextOrientedAttributesApplyToGlobal()
         {
@@ -1447,7 +1490,6 @@ namespace Spark.Tests
                 "<p>String:Hello World!</p>",
                 "<p>Int32:42</p>"));
         }
-
 
         [Test]
         public void ShadeElementsMayStackOnOneLine()

--- a/src/Spark.Web.Tests/Stubs/StubViewFactory.cs
+++ b/src/Spark.Web.Tests/Stubs/StubViewFactory.cs
@@ -26,10 +26,12 @@ namespace Spark.Tests.Stubs
         {
             var descriptor = new SparkViewDescriptor();
             descriptor.Templates.Add(Path.Combine(viewContext.ControllerName, viewContext.ViewName + (extension ?? Constants.DotSpark)));
+            
             if (viewContext.MasterName != null)
                 descriptor.Templates.Add(Path.Combine(Constants.Shared, viewContext.MasterName + (extension ?? Constants.DotSpark)));
  
             var sparkView = Engine.CreateInstance(descriptor);
+
             ((StubSparkView)sparkView).ViewData = viewContext.Data;
             ((StubSparkView)sparkView).CacheService = CacheService;
             sparkView.RenderView(new StringWriter(viewContext.Output));

--- a/src/Spark.Web.Tests/ViewActivatorTester.cs
+++ b/src/Spark.Web.Tests/ViewActivatorTester.cs
@@ -51,7 +51,6 @@ namespace Spark
 
             public void Unregister(Type type, IViewActivator activator)
             {
-
             }
 
             public ISparkView Activate(Type type)

--- a/src/Spark.Web/AbstractSparkView.cs
+++ b/src/Spark.Web/AbstractSparkView.cs
@@ -21,10 +21,10 @@ namespace Spark
             : this(null)
         {
         }
+
         protected AbstractSparkView(SparkViewBase decorated)
             : base(decorated)
         {
         }
-
     }
 }

--- a/src/Spark.Web/FileSystem/VirtualPathProviderViewFolder.cs
+++ b/src/Spark.Web/FileSystem/VirtualPathProviderViewFolder.cs
@@ -22,14 +22,12 @@ namespace Spark.FileSystem
 {
     public class VirtualPathProviderViewFolder : IViewFolder
     {
-        private readonly string _virtualBaseDir;
-
         public VirtualPathProviderViewFolder(string virtualBaseDir)
         {
-            _virtualBaseDir = virtualBaseDir.TrimEnd(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar) + "/";
+            this.VirtualBaseDir = virtualBaseDir.TrimEnd(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar) + "/";
         }
 
-        public string VirtualBaseDir => _virtualBaseDir;
+        public string VirtualBaseDir { get; }
 
         public IViewFile GetViewSource(string path)
         {
@@ -64,6 +62,7 @@ namespace Spark.FileSystem
         public IList<string> ListViews(string path)
         {
             var directory = HostingEnvironment.VirtualPathProvider.GetDirectory(Combine(path));
+
             return directory.Files.OfType<VirtualFile>().Select(f => f.VirtualPath).ToArray();
         }
 
@@ -75,7 +74,9 @@ namespace Spark.FileSystem
         private string Combine(string path)
         {
             if (string.IsNullOrEmpty(path))
-                return VirtualBaseDir;
+            {
+                return this.VirtualBaseDir;
+            }
 
             return HostingEnvironment.VirtualPathProvider.CombineVirtualPaths(VirtualBaseDir, path);
         }

--- a/src/Spark.Web/SparkViewBase.cs
+++ b/src/Spark.Web/SparkViewBase.cs
@@ -60,8 +60,7 @@ namespace Spark
             }
             set { _sparkViewContext = value; }
         }
-
-
+        
         public TextWriter Output { get { return SparkViewContext.Output; } set { SparkViewContext.Output = value; } }
         public Dictionary<string, TextWriter> Content { get { return SparkViewContext.Content; } set { SparkViewContext.Content = value; } }
         public Dictionary<string, object> Globals { get { return SparkViewContext.Globals; } set { SparkViewContext.Globals = value; } }
@@ -92,8 +91,7 @@ namespace Spark
         {
             return new MarkdownOutputScopeImpl(this, new SpoolWriter());
         }
-
-
+        
         public bool Once(object flag)
         {
             var flagString = Convert.ToString(flag);
@@ -103,8 +101,7 @@ namespace Spark
             SparkViewContext.OnceTable.Add(flagString, null);
             return true;
         }
-
-
+        
         public class OutputScopeImpl : IDisposable
         {
             private readonly SparkViewBase view;
@@ -169,7 +166,6 @@ namespace Spark
         private CacheScopeImpl _currentCacheScope;
         public ICacheService CacheService { get; set; }
 
-
         private class CacheScopeImpl
         {
             private readonly CacheScopeImpl _previousCacheScope;
@@ -190,8 +186,7 @@ namespace Spark
                 _cacheService = view.CacheService ?? _nullCacheService;
                 _originator = new CacheOriginator(view.SparkViewContext);
             }
-
-
+            
             public bool Begin()
             {
                 var memento = _cacheService.Get(_identifier) as CacheMemento;
@@ -218,8 +213,7 @@ namespace Spark
                 }
                 return _previousCacheScope;
             }
-
-
+            
             private class NullCacheService : ICacheService
             {
                 public object Get(string identifier)
@@ -242,9 +236,10 @@ namespace Spark
         }
 
         public abstract void Render();
-      protected virtual void DelegateFirstRender(Action render)
-       {
-          render();
+        
+        protected virtual void DelegateFirstRender(Action render)
+        {
+            render();
         }
     }
 

--- a/src/Spark/Bindings/DefaultBindingProvider.cs
+++ b/src/Spark/Bindings/DefaultBindingProvider.cs
@@ -12,7 +12,7 @@ namespace Spark.Bindings
         public override IEnumerable<Binding> GetBindings(BindingRequest bindingRequest)
         {
             if (bindingRequest.ViewFolder.HasView("bindings.xml") == false)
-                return new Binding[0];
+                return Array.Empty<Binding>();
 
             var file = bindingRequest.ViewFolder.GetViewSource("bindings.xml");
             using (var stream = file.OpenViewStream())

--- a/src/Spark/Compiler/CSharp/CSharpViewCompiler.cs
+++ b/src/Spark/Compiler/CSharp/CSharpViewCompiler.cs
@@ -43,21 +43,27 @@ namespace Spark.Compiler.CSharp
             var usingGenerator = new UsingNamespaceVisitor(source);
             var baseClassGenerator = new BaseClassVisitor { BaseClass = BaseClass };
             var globalsGenerator = new GlobalMembersVisitor(source, globalSymbols, NullBehaviour);
-            
-
 
             // using <namespaces>;
-            foreach (var ns in UseNamespaces ?? new string[0])
+            foreach (var ns in UseNamespaces ?? Array.Empty<string>())
+            {
                 usingGenerator.UsingNamespace(ns);
+            }
 
-            foreach (var assembly in UseAssemblies ?? new string[0])
+            foreach (var assembly in UseAssemblies ?? Array.Empty<string>())
+            {
                 usingGenerator.UsingAssembly(assembly);
+            }
 
             foreach (var resource in allResources)
+            {
                 usingGenerator.Accept(resource);
+            }
 
             foreach (var resource in allResources)
+            {
                 baseClassGenerator.Accept(resource);
+            }
 
             var viewClassName = "View" + GeneratedViewId.ToString("n");
 
@@ -77,7 +83,7 @@ namespace Spark.Compiler.CSharp
 
             source.WriteLine();
 
-			if (Descriptor != null)
+            if (Descriptor != null)
             {
                 // [SparkView] attribute
                 source.WriteLine("[global::Spark.SparkViewAttribute(");
@@ -117,7 +123,9 @@ namespace Spark.Compiler.CSharp
 
             // properties and macros
             foreach (var resource in allResources)
+            {
                 globalsGenerator.Accept(resource);
+            }
 
             // public void RenderViewLevelx()
             int renderLevel = 0;

--- a/src/Spark/Compiler/CSharp/ChunkVisitors/UsingNamespaceVisitor.cs
+++ b/src/Spark/Compiler/CSharp/ChunkVisitors/UsingNamespaceVisitor.cs
@@ -14,7 +14,6 @@
 // 
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using Spark.Compiler.ChunkVisitors;
 using Spark.Parser.Code;
 

--- a/src/Spark/Compiler/CompilerException.cs
+++ b/src/Spark/Compiler/CompilerException.cs
@@ -22,7 +22,6 @@ namespace Spark.Compiler
         public CompilerException(string message)
             : base(message)
         {
-
         }
             
         public CompilerException(string message, Position position)

--- a/src/Spark/Compiler/NodeVisitors/VisitorContext.cs
+++ b/src/Spark/Compiler/NodeVisitors/VisitorContext.cs
@@ -14,8 +14,6 @@
 // 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Spark.Bindings;
 using Spark.FileSystem;
 using Spark.Parser;
@@ -33,8 +31,8 @@ namespace Spark.Compiler.NodeVisitors
         public VisitorContext()
         {
             Namespaces = NamespacesType.Unqualified;
-            Paint = new Paint[0];
-            PartialFileNames = new string[0];
+            Paint = Array.Empty<Paint>();
+            PartialFileNames = Array.Empty<string>();
         }
 
         public ISparkSyntaxProvider SyntaxProvider { get; set; }

--- a/src/Spark/Compiler/SourceWriter.cs
+++ b/src/Spark/Compiler/SourceWriter.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -44,10 +43,7 @@ namespace Spark.Compiler
         public static bool AdjustDebugSymbolsDefault { get; set; }
         public bool AdjustDebugSymbols { get; set; }
 
-        public int Length
-        {
-            get { return _writer.GetStringBuilder().Length; }
-        }
+        public int Length => _writer.GetStringBuilder().Length;
 
         public SourceWriter AddIndent()
         {
@@ -91,14 +87,12 @@ namespace Spark.Compiler
             Indent();
         }
 
-
         public SourceWriter Write(string value)
         {
             Flush();
             _writer.Write(value);
             return this;
         }
-
 
         public SourceWriter WriteFormat(string format, params object[] args)
         {
@@ -163,7 +157,6 @@ namespace Spark.Compiler
             return true;
         }
 
-
         public SourceWriter WriteLine()
         {
             Flush();
@@ -181,8 +174,6 @@ namespace Spark.Compiler
         {
             return WriteLine(string.Format(format, args));
         }
-
-
 
         public SourceWriter WriteDirective(string line)
         {
@@ -213,11 +204,13 @@ namespace Spark.Compiler
             return this;
         }
 
+        /// <summary>
+        /// For backwards compatibility with extensions
+        /// </summary>
+        /// <returns>The string writer's string builder.</returns>
         public StringBuilder GetStringBuilder()
         {
-            // for backwards compatability with extensions
             return _writer.GetStringBuilder();
         }
-
     }
 }

--- a/src/Spark/Compiler/ViewCompiler.cs
+++ b/src/Spark/Compiler/ViewCompiler.cs
@@ -35,8 +35,8 @@ namespace Spark.Compiler
         public Guid GeneratedViewId { get; set; }
 
         public bool Debug { get; set; }
-		public NullBehaviour NullBehaviour { get; set; }
-    	public IEnumerable<string> UseNamespaces { get; set; }
+        public NullBehaviour NullBehaviour { get; set; }
+        public IEnumerable<string> UseNamespaces { get; set; }
         public IEnumerable<string> UseAssemblies { get; set; }
 
         public string TargetNamespace => Descriptor?.TargetNamespace;
@@ -44,14 +44,11 @@ namespace Spark.Compiler
         public abstract void CompileView(IEnumerable<IList<Chunk>> viewTemplates, IEnumerable<IList<Chunk>> allResources);
         public abstract void GenerateSourceCode(IEnumerable<IList<Chunk>> viewTemplates, IEnumerable<IList<Chunk>> allResources);
 
-
-
         private static Dictionary<Type, Func<ISparkView>> _ctors = new Dictionary<Type, Func<ISparkView>>();
         public ISparkView CreateInstance()
         {
             return FastActivator<ISparkView>.New(CompiledType);
         }
-
     }
 
     public static class FastActivator<TTargetClass> where TTargetClass : class

--- a/src/Spark/Compiler/VisualBasic/VisualBasicViewCompiler.cs
+++ b/src/Spark/Compiler/VisualBasic/VisualBasicViewCompiler.cs
@@ -31,7 +31,6 @@ namespace Spark.Compiler.VisualBasic
             CompiledType = assembly.GetType(ViewClassFullName);
         }
 
-
         public override void GenerateSourceCode(IEnumerable<IList<Chunk>> viewTemplates, IEnumerable<IList<Chunk>> allResources)
         {
             var globalSymbols = new Dictionary<string, object>();
@@ -50,11 +49,11 @@ namespace Spark.Compiler.VisualBasic
             source.WriteLine("Option Infer On");
 
             usingGenerator.UsingNamespace("Microsoft.VisualBasic");
-            foreach (var ns in UseNamespaces ?? new string[0])
+            foreach (var ns in UseNamespaces ?? Array.Empty<string>())
                 usingGenerator.UsingNamespace(ns);
 
             usingGenerator.UsingAssembly("Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
-            foreach (var assembly in UseAssemblies ?? new string[0])
+            foreach (var assembly in UseAssemblies ?? Array.Empty<string>())
                 usingGenerator.UsingAssembly(assembly);
 
             foreach (var resource in allResources)
@@ -74,7 +73,7 @@ namespace Spark.Compiler.VisualBasic
                 ViewClassFullName = TargetNamespace + "." + viewClassName;
 
                 source.WriteLine();
-                source.WriteLine(string.Format("Namespace {0}", TargetNamespace));
+                source.Write("Namespace ").WriteLine(TargetNamespace);
             }
 
             source.WriteLine();

--- a/src/Spark/Constants.cs
+++ b/src/Spark/Constants.cs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Spark.Compiler.NodeVisitors;
 
 namespace Spark
 {
@@ -28,15 +23,15 @@ namespace Spark
         public const string UseNamespace = "http://sparkviewengine.com/use/";
         public const string SegmentNamespace = "http://sparkviewengine.com/segment/";
         public const string RenderNamespace = "http://sparkviewengine.com/render/";
-
+        
         public const string XIncludeNamespace = "http://www.w3.org/2001/XInclude";
-
+        
         public const string SectionNamespace = "http://sparkviewengine.com/section/";
-		
-		public static readonly string Shared = "Shared";
-		public static readonly string Layouts = "Layouts";
-		public static readonly string GlobalSpark = "_global.spark";
-		public static readonly string DotSpark = ".spark";
+        
+        public static readonly string Shared = "Shared";
+        public static readonly string Layouts = "Layouts";
+        public static readonly string GlobalSpark = "_global.spark";
+        public static readonly string DotSpark = ".spark";
         public static readonly string DotShade = ".shade";
     }
 }

--- a/src/Spark/DefaultLanguageFactory.cs
+++ b/src/Spark/DefaultLanguageFactory.cs
@@ -25,11 +25,15 @@ namespace Spark
         {
             var pageBaseType = engine.Settings.PageBaseType;
             if (string.IsNullOrEmpty(pageBaseType))
+            {
                 pageBaseType = engine.DefaultPageBaseType;
+            }
 
             var language = descriptor.Language;
             if (language == LanguageType.Default)
+            {
                 language = engine.Settings.DefaultLanguage;
+            }
 
             ViewCompiler viewCompiler;
             switch (language)
@@ -51,9 +55,10 @@ namespace Spark
             viewCompiler.BaseClass = pageBaseType;
             viewCompiler.Descriptor = descriptor;
             viewCompiler.Debug = engine.Settings.Debug;
-        	viewCompiler.NullBehaviour = engine.Settings.NullBehaviour;
+            viewCompiler.NullBehaviour = engine.Settings.NullBehaviour;
             viewCompiler.UseAssemblies = engine.Settings.UseAssemblies;
             viewCompiler.UseNamespaces = engine.Settings.UseNamespaces;
+            
             return viewCompiler;
         }
 

--- a/src/Spark/FileSystem/SubViewFolder.cs
+++ b/src/Spark/FileSystem/SubViewFolder.cs
@@ -71,7 +71,7 @@ namespace Spark.FileSystem
         {
             var adjusted = Adjust(path);
             if (adjusted == null)
-                return new string[0];
+                return Array.Empty<string>();
 
             return _viewFolder.ListViews(adjusted).Select(file => Path.Combine(_subFolder, Path.GetFileName(file))).ToArray();
         }

--- a/src/Spark/ISparkSyntaxProvider.cs
+++ b/src/Spark/ISparkSyntaxProvider.cs
@@ -12,13 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // 
-using System;
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Spark.Compiler;
 using Spark.Compiler.NodeVisitors;
-using Spark.FileSystem;
 using Spark.Parser;
 using Spark.Parser.Code;
 using Spark.Parser.Markup;

--- a/src/Spark/Parser/Code/CodeGrammar.cs
+++ b/src/Spark/Parser/Code/CodeGrammar.cs
@@ -125,7 +125,7 @@ namespace Spark.Parser.Code
                                                    .Concat(hit.Left.Left.Down)
                                                    .Concat(hit.Left.Down)
                                                    .Concat(new Snippets("\""))
-                                                   .Concat(hit.Down ?? new Snippet[0])
+                                                   .Concat(hit.Down ?? Array.Empty<Snippet>())
                                                    .Concat(new Snippets(")"))
                                                    .ToList());
 

--- a/src/Spark/Parser/Offset/OffsetGrammar.cs
+++ b/src/Spark/Parser/Offset/OffsetGrammar.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Spark.Parser.Markup;
 
@@ -51,7 +52,7 @@ namespace Spark.Parser.Offset
             var ows = Rep(Ch(' ', '\t'));
 
             var whiteLine = lineBreakOrStart.And(Rep(Ch(' ', '\t'))).IfNext(lineBreakOrEnd)
-                .Build(hit => new Node[0]);
+                .Build(hit => Array.Empty<Node>());
 
             //[4]   	NameChar	   ::=   	 Letter | Digit | '.' | '-' | '_' | ':' | CombiningChar | Extender  
             var NameChar = Ch(char.IsLetterOrDigit).Or(Ch(/*'.',*/ '-', '_', ':'))/*.Or(CombiningChar).Or(Extener)*/;
@@ -102,14 +103,14 @@ namespace Spark.Parser.Offset
                                       attrs =
                                   (hit.Down.id != null
                                        ? new[] { new AttributeNode("id", hit.Down.id) }
-                                       : new AttributeNode[0])
+                                       : Array.Empty<AttributeNode>())
                                   .Concat(hit.Down.classes.Any()
                                               ? new[]
                                                     {
                                                         new AttributeNode("class",
                                                                           string.Join(" ", hit.Down.classes.ToArray()))
                                                     }
-                                              : new AttributeNode[0])
+                                              : Array.Empty<AttributeNode>())
                                   });
 
             var element = elementLeadin.And(Rep(Attribute.Skip(ows)))
@@ -124,12 +125,12 @@ namespace Spark.Parser.Offset
 
             var elementPlus = element.Skip(ows).And(Opt(elementFollower));
 
-            var line1 = indentation.And(elementPlus).Build(hit => new[] { hit.Left, (Node)hit.Down.Left }.Concat(hit.Down.Down??new Node[0]).ToArray());
+            var line1 = indentation.And(elementPlus).Build(hit => new[] { hit.Left, (Node)hit.Down.Left }.Concat(hit.Down.Down?? Array.Empty<Node>()).ToArray());
             //var line2 = indentation.And(text).Build(hit => new Node[] { hit.Left, hit.Down });
             var line2 = indentation.And(texts).Build(hit => new Node[] { hit.Left }.Concat(hit.Down).ToArray());
             var line3 = indentation.And(expression).Build(hit => new Node[] { hit.Left, hit.Down });
             var line4 = indentation.And(statement).Build(hit => new Node[] { hit.Left, hit.Down });
-            var line5 = elementPlus.Build(hit => new[] {(Node) hit.Left}.Concat(hit.Down ?? new Node[0]).ToArray());
+            var line5 = elementPlus.Build(hit => new[] {(Node) hit.Left}.Concat(hit.Down ?? Array.Empty<Node>()).ToArray());
 
             var line = whiteLine.Or(line1).Or(line2).Or(line3).Or(line4).Or(line5).Skip(ows);
 

--- a/src/Spark/SparkBatchDescriptor.cs
+++ b/src/Spark/SparkBatchDescriptor.cs
@@ -54,7 +54,7 @@ namespace Spark
         public SparkBatchDescriptor FromAttributes(Type controllerType)
         {
             var precompileAttributes = controllerType.GetCustomAttributes(typeof(PrecompileAttribute), true);
-            foreach (PrecompileAttribute precompileAttribute in precompileAttributes ?? new object[0])
+            foreach (PrecompileAttribute precompileAttribute in precompileAttributes ?? Array.Empty<object>())
             {
                 var config = For(controllerType);
                 foreach (var item in SplitParts(precompileAttribute.Include))

--- a/src/Spark/SparkViewAttribute.cs
+++ b/src/Spark/SparkViewAttribute.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace Spark
 {	
-	public class SparkViewAttribute : Attribute
+    public class SparkViewAttribute : Attribute
     {
         public string TargetNamespace { get; set; }
         public string[] Templates { get; set; }
@@ -26,10 +26,10 @@ namespace Spark
         public SparkViewDescriptor BuildDescriptor()
         {
             return new SparkViewDescriptor
-			{
-				TargetNamespace = TargetNamespace,
-				Templates = Templates.Select(t => ConvertFromAttributeFormat(t)).ToList()
-			};
+            {
+                TargetNamespace = TargetNamespace,
+                Templates = Templates.Select(t => ConvertFromAttributeFormat(t)).ToList()
+            };
         }
 
         public static string ConvertToAttributeFormat(string template)
@@ -46,10 +46,10 @@ namespace Spark
             // when compiled attributes are bound into descriptors, the
             // backslashes are treated as environment-specific seperators
             if (Path.DirectorySeparatorChar == '\\')
-			{
-				return template;
-			}
-			
+            {
+                return template;
+            }
+            
             return template.Replace('\\', Path.DirectorySeparatorChar);
         }
     }

--- a/src/Spark/SparkViewDescriptor.cs
+++ b/src/Spark/SparkViewDescriptor.cs
@@ -81,7 +81,9 @@ namespace Spark
                 ^ (TargetNamespace ?? "").GetHashCode();
 
             foreach (var template in Templates)
+            {
                 hashCode ^= template.ToLowerInvariant().GetHashCode();
+            }
 
             return hashCode;
         }
@@ -91,7 +93,9 @@ namespace Spark
             var that = obj as SparkViewDescriptor;
 
             if (that == null || GetType() != that.GetType())
+            {
                 return false;
+            }
 
             if (!string.Equals(TargetNamespace ?? "", that.TargetNamespace ?? "") ||
                 Language != that.Language ||

--- a/src/Spark/SparkViewEngine.cs
+++ b/src/Spark/SparkViewEngine.cs
@@ -246,14 +246,16 @@ namespace Spark
         public ISparkViewEntry CreateEntry(SparkViewDescriptor descriptor)
         {
             var entry = CompiledViewHolder.Lookup(descriptor);
+
             if (entry == null)
             {
                 entry = CreateEntryInternal(descriptor, true);
+
                 CompiledViewHolder.Store(entry);
             }
+
             return entry;
         }
-
 
         public ISparkViewEntry CreateEntryInternal(SparkViewDescriptor descriptor, bool compile)
         {
@@ -265,9 +267,9 @@ namespace Spark
                 LanguageFactory = LanguageFactory
             };
 
-
             var chunksLoaded = new List<IList<Chunk>>();
             var templatesLoaded = new List<string>();
+
             LoadTemplates(entry.Loader, entry.Descriptor.Templates, chunksLoaded, templatesLoaded);
 
             if (compile)
@@ -290,9 +292,7 @@ namespace Spark
             {
                 if (templatesLoaded.Contains(template))
                 {
-                    throw new CompilerException(string.Format(
-                        "Unable to include template '{0}' recusively",
-                        templates));
+                    throw new CompilerException($"Unable to include template '{templates}' recursively");
                 }
 
                 var chunks = loader.Load(template);
@@ -353,8 +353,10 @@ namespace Spark
             {
                 entry.Compiler.CompiledType = assembly.GetType(entry.Compiler.ViewClassFullName);
                 entry.Activator = ViewActivatorFactory.Register(entry.Compiler.CompiledType);
+
                 CompiledViewHolder.Store(entry);
             }
+
             return assembly;
         }
 
@@ -365,11 +367,15 @@ namespace Spark
             foreach (var type in assembly.GetExportedTypes())
             {
                 if (!typeof(ISparkView).IsAssignableFrom(type))
+                {
                     continue;
+                }
 
                 var attributes = type.GetCustomAttributes(typeof(SparkViewAttribute), false);
                 if (attributes == null || attributes.Length == 0)
+                {
                     continue;
+                }
 
                 var descriptor = ((SparkViewAttribute)attributes[0]).BuildDescriptor();
 
@@ -387,6 +393,5 @@ namespace Spark
 
             return descriptors;
         }
-
     }
 }

--- a/src/Spark/Spool/SpoolReader.cs
+++ b/src/Spark/Spool/SpoolReader.cs
@@ -48,18 +48,6 @@ namespace Spark.Spool
             return ch;
         }
 
-        // TODO : Remove when Mono 2.10.2 is out
-        public override string ReadToEnd()
-        {
-            var result = new System.Text.StringBuilder();
-            int c;
-            while ((c = Read()) != -1)
-            {
-                result.Append((char)c);
-            }
-            return result.ToString();
-        }
-
         //TODO: override read byte[] for efficiency
     }
 }


### PR DESCRIPTION
A bit of digital _dusting_. No functional change.

- Using Array.Empty<class>() instead of new class[0]
- if and for have their block wrapped in {}
- Removed unused usings
- Removed unused variables
- Fixed indentation
- CSharp modernization (leveraging newer language features)
- Fixed typos
- Improved readability of some unit tests by adding a new line before
- No longer overriding ReadToEnd() in SpoolReader.cs (mono 2.10.2 _is_ out)