### PR TITLE
Templates of generic controllers are now pre-compiled

### DIFF
--- a/src/Spark.Web.Mvc/SparkViewFactory.cs
+++ b/src/Spark.Web.Mvc/SparkViewFactory.cs
@@ -276,7 +276,22 @@ namespace Spark.Web.Mvc
         {
             var descriptors = new List<SparkViewDescriptor>();
 
-            var controllerName = RemoveSuffix(entry.ControllerType.Name, "Controller");
+            string controllerName = null;
+
+            if (entry.ControllerType.ContainsGenericParameters)
+            {
+                // generic controller have a backtick suffix in their (name e.g. "SomeController`2")
+                var indexOfBacktick = entry.ControllerType.Name.IndexOf("Controller`", StringComparison.Ordinal);
+                if (indexOfBacktick > -1)
+                {
+                    // removing it otherwise locating the view templates will fail
+                    controllerName = entry.ControllerType.Name.Substring(0, indexOfBacktick);
+                }
+            }
+            else
+            {
+                controllerName = RemoveSuffix(entry.ControllerType.Name, "Controller");
+            }
 
             var viewNames = new List<string>();
 
@@ -375,12 +390,9 @@ namespace Spark.Web.Mvc
 
         private static string RemoveSuffix(string value, string suffix)
         {
-            if (value.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return value.Substring(0, value.Length - suffix.Length);
-            }
-
-            return value;
+            return value.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase) 
+                ? value.Substring(0, value.Length - suffix.Length) 
+                : value;
         }
 
         #region IViewEngine Members


### PR DESCRIPTION
If you use generic controller the name of the class is going to be BlahController`X (where X is the number of generic parameters).

This was preventing views from being located when precompiling.